### PR TITLE
feat: support langs option in find command

### DIFF
--- a/src/keys-detective/index.ts
+++ b/src/keys-detective/index.ts
@@ -3,6 +3,7 @@ import { buildKeys } from '../keys-builder/build-keys';
 import { messages } from '../messages';
 import { Config } from '../types';
 import { getLogger } from '../utils/logger';
+import { filterPathByLang } from '../utils/path.utils';
 import { resolveConfig } from '../utils/resolve-config';
 
 import { compareKeysToFiles } from './compare-keys-to-files';
@@ -10,14 +11,14 @@ import { getTranslationFilesPath } from './get-translation-files-path';
 
 export function findMissingKeys(inlineConfig: Config) {
   const logger = getLogger();
-  const config = resolveConfig(inlineConfig);
+  const config = resolveConfig({ langs:[], ...inlineConfig });
   setConfig(config);
 
-  const { translationsPath, fileFormat } = config;
+  const { translationsPath, fileFormat, langs = [] } = config;
   const translationFiles = getTranslationFilesPath(
     translationsPath,
     fileFormat
-  );
+  ).filter(filterPathByLang(langs, config));
 
   if (translationFiles.length === 0) {
     console.log('No translation files found.');
@@ -37,5 +38,6 @@ export function findMissingKeys(inlineConfig: Config) {
     addMissingKeys,
     emitErrorOnExtraKeys,
     fileFormat,
+    langs,
   });
 }

--- a/src/utils/path.utils.ts
+++ b/src/utils/path.utils.ts
@@ -24,6 +24,22 @@ interface Options extends Pick<Config, 'fileFormat' | 'translationsPath'> {
   filePath: string;
 }
 
+export function filterPathByLang(
+  langs: ReadonlyArray<string>,
+  options: Pick<Config, 'fileFormat' | 'translationsPath'>
+) {
+  const langsAsSet = new Set(langs);
+
+  return (filePath: string) => {
+    if (langsAsSet.size > 0) {
+      const { lang } = getScopeAndLangFromPath({ filePath, ...options });
+      return langsAsSet.has(lang);
+    } else {
+      return true;
+    }
+  };
+}
+
 /**
  * /Users/username/www/folderName/src/assets/i18n/admin/es.json => { scope: admin, lang: es }
  * /Users/username/www/folderName/src/assets/i18n/es.json => { scope: undefined, lang: es }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: jsverse/transloco#957 138

## What is the new behavior?

The find command respects the langs option and only processes files for the specified languages. If the langs option is not present, all files will be processed.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Usages of the find command, that specify languages using the langs option will behave differently. Instead of processing all existing file, only those files specified in the langs options will be processed.

Migration: If you want to process all files, remove the langs option from the find command invocation.

## Other information
