### PR TITLE
fix: resolveProjectBasePath could not find source root when directory…

### DIFF
--- a/src/utils/resolve-project-base-path.ts
+++ b/src/utils/resolve-project-base-path.ts
@@ -44,13 +44,24 @@ export function resolveProjectBasePath(projectName?: string): {
 } {
   let projectPath = '';
 
+  let projectConfig;
   if (projectName) {
-    projectPath = normalizedGlob(`**/${projectName}`)[0];
+    // look for all project.json files and find the project.json that contains
+    // { name: "<projectName>" ... }
+    const projectConfigs = normalizedGlob(`**/${projectConfigFile}`);
+    for(const p of projectConfigs) {
+      const config = searchConfig(projectConfigFile, p);
+      if(config.name === projectName) {
+        projectConfig = config;
+        break;
+      }
+    }
+  } else {
+    projectConfig = searchConfig(projectConfigFile, projectPath);
   }
 
   const angularConfig = searchConfig(angularConfigFile, projectPath);
   const workspaceConfig = searchConfig(workspaceConfigFile, projectPath);
-  const projectConfig = searchConfig(projectConfigFile, projectPath);
 
   if (!angularConfig && !workspaceConfig && !projectConfig) {
     logNotFound([...angularConfigFile, workspaceConfigFile, projectConfigFile]);


### PR DESCRIPTION
… name and project name are different

prior to this change we would look for `**/<projectName>` however this does not work when we have a folder structure like: `/libs/ui/my-button` where the project name would be `ui-my-button` causing the keys not to be detected this change would look for all project.json files and look for the correct project.json by comparing the name property within

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently when having a folder structure where the project name does not match the folder name transloco-key-manager is unable to find the source root.

for example if we would have
libs/booking/ui/button when looking for a project with the name `booking-ui-button` transloco won't find the source root of this project causing the error:
![image](https://user-images.githubusercontent.com/4212850/233839638-3d51d7c2-9a89-467a-9201-df1d3264c1c1.png)



Issue Number: N/A

## What is the new behavior?
with the changes in this PR we look for all `project.json` and compare the `name` property to find out if it is the correct config file.

this enables us to have folder structures like
/booking/ui/button
/booking/ui/card
/invoicing/ui/button

And before when running `npx transloco-keys-manager extract --project=button` it would match one of these libraries but never the other. This change would also make this possible where everything is correctly matched based on the project name that is specified in project.json ( project name should still be unique in each workspace else `nx` will not work correctly either ). 

## Does this PR introduce a breaking change?
```
[ ] Yes
[X ] No

## Other information
