### PR TITLE
feat: handle scoped only libs

### DIFF
--- a/src/keys-builder/create-translation-files.ts
+++ b/src/keys-builder/create-translation-files.ts
@@ -14,6 +14,7 @@ export async function createTranslationFiles({
   removeExtraKeys,
   scopes,
   fileFormat,
+  scopedOnly,
 }: Config & { scopeToKeys: ScopeMap }) {
   const logger = getLogger();
 
@@ -23,21 +24,24 @@ export async function createTranslationFiles({
     output,
     fileFormat,
   });
-  const globalFiles = langs.map((lang) => ({
-    path: `${output}/${lang}.${fileFormat}`,
-  }));
+
   const actions: FileAction[] = [];
 
-  for (const { path } of globalFiles) {
-    actions.push(
-      buildTranslationFile({
-        path,
-        translation: scopeToKeys.__global,
-        replace,
-        removeExtraKeys,
-        fileFormat,
-      }),
-    );
+  if (!scopedOnly) {
+    const globalFiles = langs.map((lang) => ({
+      path: `${output}/${lang}.${fileFormat}`,
+    }));
+    for (const { path } of globalFiles) {
+      actions.push(
+        buildTranslationFile({
+          path,
+          translation: scopeToKeys.__global,
+          replace,
+          removeExtraKeys,
+          fileFormat,
+        }),
+      );
+    }
   }
 
   for (const { path, scope } of scopeFiles) {

--- a/src/keys-builder/index.ts
+++ b/src/keys-builder/index.ts
@@ -1,6 +1,6 @@
 import { setConfig } from '../config';
 import { messages } from '../messages';
-import { Config } from '../types';
+import { Config, ScopeMap } from '../types';
 import { countKeys } from '../utils/keys.utils';
 import { getLogger } from '../utils/logger';
 import { resolveConfig } from '../utils/resolve-config';
@@ -23,6 +23,19 @@ export async function buildTranslationFiles(inlineConfig: Config) {
   const result = buildKeys(config);
   const { scopeToKeys, fileCount } = result;
 
+  if (config.scopedOnly) {
+    if (Object.keys(scopeToKeys.__global).length) {
+      logger.log(
+        '\n\x1b[31m%s\x1b[0m',
+        '⚠️',
+        'Global keys found with scopedOnly flag active\n'
+      );
+      if (config.emitErrorOnExtraKeys) {
+        process.exit(2);
+      }
+    }
+    delete (scopeToKeys as Partial<ScopeMap>).__global;
+  }
   logger.success(`${messages.extract} 🗝`);
 
   let keysFound = 0;

--- a/src/keys-detective/index.ts
+++ b/src/keys-detective/index.ts
@@ -1,7 +1,7 @@
 import { setConfig } from '../config';
 import { buildKeys } from '../keys-builder/build-keys';
 import { messages } from '../messages';
-import { Config } from '../types';
+import { Config, ScopeMap } from '../types';
 import { getLogger } from '../utils/logger';
 import { resolveConfig } from '../utils/resolve-config';
 
@@ -29,6 +29,19 @@ export function findMissingKeys(inlineConfig: Config) {
 
   const result = buildKeys(config);
   logger.success(`${messages.extract} 🗝`);
+  if (config.scopedOnly) {
+    if (Object.keys(result.scopeToKeys.__global).length) {
+      logger.log(
+        '\n\x1b[31m%s\x1b[0m',
+        '⚠️',
+        'Global keys found with scopedOnly flag active\n'
+      );
+      if (config.emitErrorOnExtraKeys) {
+        process.exit(2);
+      }
+    }
+    delete (result.scopeToKeys as Partial<ScopeMap>).__global;
+  }
 
   const { addMissingKeys, emitErrorOnExtraKeys } = config;
   compareKeysToFiles({

--- a/src/marker.ts
+++ b/src/marker.ts
@@ -1,3 +1,7 @@
-export function marker<T extends string | string[]>(key: T): T {
+export function marker<T extends string | string[]>(
+  key: T,
+  params?: unknown,
+  lang?: string
+): T {
   return key;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type Config = {
   addMissingKeys: boolean;
   removeExtraKeys: boolean;
   emitErrorOnExtraKeys: boolean;
+  scopedOnly?: boolean;
   scopes: Scopes;
   scopePathMap?: {
     [scopeAlias: string]: string;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?


```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: [178](https://github.com/jsverse/transloco/issues/964)
Issue Number: [132](https://github.com/jsverse/transloco-keys-manager/issues/132)

As stated in the first linked issue, when using libraries that only need scoped translation you end up with unused files generated because of the "__global" scope. 

## What is the new behavior?
Using a new scopedOnly option in the config file, we can now tell the builder and finder, to only check for the files in the scopePathMap and ignore everything in the __global scope. If you have the emitErrorOnExtraKeys option enabled you''l get an error if the key builder detects global keys, only a warning otherwise.
 With this options, you should now be able to have only one translation file per library per lang and, if you want to, have this file at the root path (rootTranslationsPath option) 
Also updated the marker typing according to the second issue.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
I'll add tests and documentation if you feel the PR is acceptable 😄  
