### PR TITLE
fix: 🐛 jsverse import resolution

### DIFF
--- a/__tests__/comments/1.ts
+++ b/__tests__/comments/1.ts
@@ -1,4 +1,4 @@
-import { translate } from '@ngneat/transloco';
+import { translate } from '@jsverse/transloco';
 
 class a {
   /**

--- a/__tests__/comments/2.ts
+++ b/__tests__/comments/2.ts
@@ -4,7 +4,7 @@
 
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, forwardRef, HostBinding, Input, Output, ViewEncapsulation } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { translate } from '@ngneat/transloco';
+import { translate } from '@jsverse/transloco';
 
 export type ExtendedGridOptions = {
   onRowDataUpdated: (event) => void;

--- a/__tests__/comments/3.ts
+++ b/__tests__/comments/3.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { TRANSLOCO_SCOPE } from '@ngneat/transloco';
+import { TRANSLOCO_SCOPE } from '@jsverse/transloco';
 
 @Component({
   selector: 'app-home',

--- a/__tests__/inline-template/2.ts
+++ b/__tests__/inline-template/2.ts
@@ -15,7 +15,7 @@ import {
   TranslocoService,
   translate,
   TRANSLOCO_SCOPE,
-} from '@ngneat/transloco';
+} from '@jsverse/transloco';
 import { untilDestroyed } from 'ngx-take-until-destroy';
 
 @Component({

--- a/__tests__/marker/basic.ts
+++ b/__tests__/marker/basic.ts
@@ -1,4 +1,4 @@
-import { marker } from '@ngneat/transloco-keys-manager/marker';
+import { marker } from '@jsverse/transloco-keys-manager/marker';
 
 @Component({
   selector: 'bla-bla',

--- a/__tests__/marker/with-alias.ts
+++ b/__tests__/marker/with-alias.ts
@@ -1,4 +1,4 @@
-import { marker as t } from '@ngneat/transloco-keys-manager/marker';
+import { marker as t } from '@jsverse/transloco-keys-manager/marker';
 
 @Component({
   selector: 'bla-bla',

--- a/__tests__/service/1.ts
+++ b/__tests__/service/1.ts
@@ -15,7 +15,7 @@ import {
   TranslocoService,
   translate,
   TRANSLOCO_SCOPE,
-} from '@ngneat/transloco';
+} from '@jsverse/transloco';
 import { untilDestroyed } from 'ngx-take-until-destroy';
 /** t(18) * */
 @Component({

--- a/__tests__/service/2.ts
+++ b/__tests__/service/2.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, Inject, OnDestroy, OnInit, Renderer2, ViewChild } from '@angular/core';
-import { TranslocoService, TRANSLOCO_SCOPE } from '@ngneat/transloco';
+import { TranslocoService, TRANSLOCO_SCOPE } from '@jsverse/transloco';
 
 const SEARCH_INTERVAL = 400;
 const ITEM_ANIMATION_DURATION = 350;

--- a/__tests__/service/3.ts
+++ b/__tests__/service/3.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, inject } from '@angular/core';
-import { TranslocoService } from '@ngneat/transloco';
+import { TranslocoService } from '@jsverse/transloco';
 
 @Component({
   selector: 'inject-test',

--- a/__tests__/unflat/1.ts
+++ b/__tests__/unflat/1.ts
@@ -1,4 +1,4 @@
-import { } from '@ngneat/transloco';
+import { } from '@jsverse/transloco';
 
 class a {
   /** t(a.1) */

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ngneat/transloco-keys-manager.git"
+    "url": "git+https://github.com/jsverse/transloco-keys-manager.git"
   },
   "keywords": [
     "angular",
@@ -57,9 +57,9 @@
     }
   ],
   "bugs": {
-    "url": "https://github.com/ngneat/transloco-keys-manager/issues"
+    "url": "https://github.com/jsverse/transloco-keys-manager/issues"
   },
-  "homepage": "https://github.com/ngneat/transloco-keys-manager#readme",
+  "homepage": "https://github.com/jsverse/transloco-keys-manager#readme",
   "config": {
     "commitizen": {
       "path": "cz-conventional-changelog"

--- a/src/keys-builder/typescript/index.ts
+++ b/src/keys-builder/typescript/index.ts
@@ -23,16 +23,18 @@ export function extractTSKeys(config: Config): ExtractionResult {
   return extractKeys(config, 'ts', TSExtractor);
 }
 
+const translocoImport = /@(jsverse|ngneat)\/transloco/;
+const translocoKeysManagerImport = /@(jsverse|ngneat)\/transloco-keys-manager/;
 function TSExtractor(config: ExtractorConfig): ScopeMap {
   const { file, scopes, defaultValue, scopeToKeys } = config;
   const content = readFile(file);
   const extractors = [];
 
-  if (content.includes('@ngneat/transloco')) {
+  if (translocoImport.test(content)) {
     extractors.push(serviceExtractor, pureFunctionExtractor);
   }
 
-  if (content.includes('@ngneat/transloco-keys-manager')) {
+  if (translocoKeysManagerImport.test(content)) {
     extractors.push(markerExtractor);
   }
 

--- a/src/keys-builder/typescript/marker.extractor.ts
+++ b/src/keys-builder/typescript/marker.extractor.ts
@@ -8,7 +8,7 @@ export function markerExtractor(ast: SourceFile): TSExtractorResult {
   // workaround from https://github.com/estools/esquery/issues/68
   const [importNode] = tsquery(
     ast,
-    `ImportDeclaration:has([text=/^@ngneat\\x2Ftransloco-keys-manager/])`,
+    `ImportDeclaration:has([text=/^@(jsverse|ngneat)\\x2Ftransloco-keys-manager/])`,
   );
   if (!importNode) {
     return [];


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

If you migrate to transloco 7 and update the imports, transloco-keys-extactro no longer works.
Indeed, extraction based on `@ngneat` imports does not work with `@jsverse`.

## What is the new behavior?

The extraction of service, pipe and marker work with the `@jsverse` imports (and `@ngneat` for backwards compatibility).

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
@shaharkazaz This is quite important!