### PR TITLE
feat: 🎸 add support of provideTranslocoScope

### DIFF
--- a/__tests__/buildTranslationFiles.spec.ts
+++ b/__tests__/buildTranslationFiles.spec.ts
@@ -64,6 +64,7 @@ type TranslationCategory =
   | 'unflat-sort'
   | 'unflat-problematic-keys'
   | 'multi-input'
+  | 'scope'
   | 'scope-mapping'
   | 'comments'
   | 'remove-extra-keys'
@@ -294,6 +295,42 @@ describe.each(formats)('buildTranslationFiles in %s', (fileFormat) => {
           expected: expected.todos,
           path: 'todos-page/',
           fileFormat,
+        });
+      });
+    });
+
+    describe('scope', () => {
+      const type: TranslationCategory = 'scope';
+      const config = gConfig(type);
+
+      beforeEach(() => removeI18nFolder(type));
+
+      it('should work with scope', () => {
+        const scopes = [
+          'scope1',
+          'scope2',
+          'scope3',
+          'scope4',
+          'scope5',
+          'scope6',
+          'scope7',
+          'scope8',
+          'scope9',
+        ];
+
+        const expected = scopes.reduce(
+          (acc, scope) => ({ ...acc, [scope]: generateKeys({ end: 1 }) }),
+          {},
+        );
+
+        createTranslations(config);
+        scopes.forEach((scope) => {
+          assertTranslation({
+            type,
+            expected: expected[scope],
+            path: `${scope}/`,
+            fileFormat,
+          });
         });
       });
     });

--- a/__tests__/scope-mapping/component-scopes.ts
+++ b/__tests__/scope-mapping/component-scopes.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { TRANSLOCO_SCOPE, provideTranslocoScope } from '@jsverse/transloco';
+
+@Component({
+  selector: 'app-home',
+  templateUrl: './home.component.html',
+  providers: [
+    { provide: TRANSLOCO_SCOPE, useValue: 'scope4' },
+    { provide: TRANSLOCO_SCOPE, useValue: { scope: 'scope5' } },
+    { provide: TRANSLOCO_SCOPE, useValue: { scope: 'scope6', alias: 'scopeAlias6' } },
+    provideTranslocoScope('scope7'),
+    provideTranslocoScope({ scope: 'scope8' }),
+    provideTranslocoScope({ scope: 'scope9', alias: 'scopeAlias9' }),
+  ],
+  styleUrls: ['./home.component.scss']
+})
+export class HomeComponent {}

--- a/__tests__/scope-mapping/scopes.ts
+++ b/__tests__/scope-mapping/scopes.ts
@@ -1,0 +1,6 @@
+export const d = {
+  provide: TRANSLOCO_SCOPE,
+  useValue: 'scope1',
+};
+export const b = provideTranslocoScope({ scope: 'scope2', alias: 'scopeAlias2' });
+export const c = provideTranslocoScope('scope3');

--- a/__tests__/scope/1.html
+++ b/__tests__/scope/1.html
@@ -1,0 +1,36 @@
+<span *transloco="let t; read: 'scope1'">
+  {{ t('1') }}
+</span>
+
+<span *transloco="let t; read: 'scopeAlias2'">
+  {{ t('1') }}
+</span>
+
+<span *transloco="let t; read: 'scope3'">
+  {{ t('1') }}
+</span>
+
+<span *transloco="let t; read: 'scope4'">
+  {{ t('1') }}
+</span>
+
+<span *transloco="let t; read: 'scope5'">
+  {{ t('1') }}
+</span>
+
+<span *transloco="let t; read: 'scopeAlias6'">
+  {{ t('1') }}
+</span>
+
+<span *transloco="let t; read: 'scope7'">
+  {{ t('1') }}
+</span>
+
+<span *transloco="let t; read: 'scope8'">
+  {{ t('1') }}
+</span>
+
+<span *transloco="let t; read: 'scopeAlias9'">
+  {{ t('1') }}
+</span>
+

--- a/__tests__/scope/component-scopes.ts
+++ b/__tests__/scope/component-scopes.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { TRANSLOCO_SCOPE, provideTranslocoScope } from '@jsverse/transloco';
+
+@Component({
+  selector: 'app-home',
+  templateUrl: './home.component.html',
+  providers: [
+    { provide: TRANSLOCO_SCOPE, useValue: 'scope4' },
+    { provide: TRANSLOCO_SCOPE, useValue: { scope: 'scope5' } },
+    { provide: TRANSLOCO_SCOPE, useValue: { scope: 'scope6', alias: 'scopeAlias6' } },
+    provideTranslocoScope('scope7'),
+    provideTranslocoScope({ scope: 'scope8' }),
+    provideTranslocoScope({ scope: 'scope9', alias: 'scopeAlias9' }),
+  ],
+  styleUrls: ['./home.component.scss']
+})
+export class HomeComponent {}

--- a/__tests__/scope/scopes.ts
+++ b/__tests__/scope/scopes.ts
@@ -1,0 +1,6 @@
+export const d = {
+  provide: TRANSLOCO_SCOPE,
+  useValue: 'scope1',
+};
+export const b = provideTranslocoScope({ scope: 'scope2', alias: 'scopeAlias2' });
+export const c = provideTranslocoScope('scope3');

--- a/src/utils/update-scopes-map.ts
+++ b/src/utils/update-scopes-map.ts
@@ -15,21 +15,21 @@ import { readFile } from './file.utils';
 import { toCamelCase } from './string.utils';
 import { normalizedGlob } from './normalize-glob-path';
 
-type Alias = string;
 type Scope = string;
+type Alias = string;
 
 interface ScopeDef {
-  scope?: Alias;
-  alias?: Scope;
+  scope?: Scope;
+  alias?: Alias;
 }
 
 interface QueryDef {
   query: string;
-  resolver: (node: Node[]) => ScopeDef | ScopeDef[];
+  resolver: (node: Node[]) => ScopeDef;
 }
 
-// TODO add provideScope
-const baseQuery = `ObjectLiteralExpression:has(PropertyAssignment > Identifier[name=TRANSLOCO_SCOPE]) PropertyAssignment:has(Identifier[name=/useValue|useFactory/])`;
+const tokenProviderQuery = `ObjectLiteralExpression:has(PropertyAssignment > Identifier[name=TRANSLOCO_SCOPE]) > PropertyAssignment > Identifier[name=/useValue|useFactory/]`;
+const functionProviderQuery = `CallExpression > Identifier[name=provideTranslocoScope]`;
 
 const stringQueryDef: QueryDef = {
   query: `StringLiteral`,
@@ -37,7 +37,7 @@ const stringQueryDef: QueryDef = {
 };
 
 const objectQueryDef: QueryDef = {
-  query: 'ObjectLiteralExpression',
+  query: 'ObjectLiteralExpression:has(Identifier[name=scope])',
   resolver: ([node]) => {
     let result: ScopeDef = {};
 
@@ -55,19 +55,12 @@ const objectQueryDef: QueryDef = {
   },
 };
 
-const arrayQueryDef: QueryDef = {
-  query: 'ArrayLiteralExpression > StringLiteral',
-  resolver: (nodes) =>
-    (nodes as StringLiteral[]).map((node) => ({ scope: node.text })),
-};
-
-const scopeValueQueries: QueryDef[] = [
-  stringQueryDef,
-  objectQueryDef,
-  arrayQueryDef,
-];
+// Order is important, we check is is object first, then string
+const scopeValueQueries: QueryDef[] = [objectQueryDef, stringQueryDef];
 
 type Options = { input?: string[]; files?: string[] };
+
+const translocoProvider = /(TRANSLOCO_SCOPE|provideTranslocoScope)/;
 
 export function updateScopesMap(
   options: Omit<Options, 'input'>,
@@ -87,21 +80,30 @@ export function updateScopesMap({
   for (const file of tsFiles) {
     const content = readFile(file);
 
-    if (!content.includes('TRANSLOCO_SCOPE')) continue;
+    if (!translocoProvider.test(content)) continue;
 
-    let result: ScopeDef | ScopeDef[] | undefined;
+    let result: ScopeDef[] = [];
 
     const ast = tsquery.ast(content);
 
-    for (const { query, resolver } of scopeValueQueries) {
-      const nodes = tsquery(ast, `${baseQuery} > ${query}`);
-      if (nodes.length > 0) {
-        result = resolver(nodes);
-        break;
+    // :has(> child) is not supported ... So we need to use a workaround, select child and make second query for parent
+    const tokenAndProviderNodes = tsquery(
+      ast,
+      `${tokenProviderQuery}, ${functionProviderQuery}`,
+    );
+
+    for (const node of tokenAndProviderNodes) {
+      // Order is important, we check is is object first, then string
+      for (const { query, resolver } of scopeValueQueries) {
+        const nodes = tsquery(node.parent, query);
+        if (nodes.length > 0) {
+          result.push(resolver(nodes));
+          break;
+        }
       }
     }
 
-    for (let { scope, alias } of coerceArray(result)) {
+    for (let { scope, alias } of result) {
       if (scope && !hasScope(scope)) {
         alias ??= toCamelCase(scope);
         addScope(scope, alias);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The new `provideTranslocoScope` is not supported:
```typescript
    provideTranslocoScope('scope7'),
    provideTranslocoScope({ scope: 'scope8' }),
    provideTranslocoScope({ scope: 'scope9', alias: 'scopeAlias9' }),
```

Also, many declarations of scope in same file, provider is not supported:
```ts
export const d = { provide: TRANSLOCO_SCOPE, useValue: 'scope1' };
export const d = { provide: TRANSLOCO_SCOPE, useValue: 'scope14' };
export const b = provideTranslocoScope({ scope: 'scope2', alias: 'scopeAlias2' });
export const c = provideTranslocoScope('scope3');
```

There is also a supporting case which is not in the transloco typing:
```ts
export const d = { provide: TRANSLOCO_SCOPE, useValue: ['scope1', 'scope2'] };
```

Issue Number: #178

## What is the new behavior?

`provideTranslocoScope` is now supported.
Multiple declaration of scope is supported.
Removal of scope array support, no typed in transloco.

## Does this PR introduce a breaking change?

```
[] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
I add `scope` test suite, because in a future PR I plan to correct the fact that `read` and `scope` are mixed up in the extraction.