### PR TITLE
fix: 🐛 comments with prefix not extracted (#197)

### DIFF
--- a/__tests__/buildTranslationFiles/comments/comments-spec.ts
+++ b/__tests__/buildTranslationFiles/comments/comments-spec.ts
@@ -31,6 +31,7 @@ export function testCommentsExtraction(fileFormat: Config['fileFormat']) {
           'a.some.key': defaultValue,
           'b.some.key': defaultValue,
           'c.some.key': defaultValue,
+          'prefix_c.some.key': defaultValue,
           'need.transloco': defaultValue,
           '1.some': defaultValue,
           ...generateKeys({ end: 8 }),

--- a/__tests__/buildTranslationFiles/comments/src/1.html
+++ b/__tests__/buildTranslationFiles/comments/src/1.html
@@ -7,4 +7,9 @@
         <!-- t(some.key) -->
         <p >{{ t(title) }}</p>
     </ng-container>
+
+    <ng-container *transloco="let t; prefix: 'prefix_c'">
+        <!-- t(some.key) -->
+        <p >{{ t(title) }}</p>
+    </ng-container>
 </div>

--- a/src/keys-builder/template/comments.extractor.ts
+++ b/src/keys-builder/template/comments.extractor.ts
@@ -120,14 +120,14 @@ function extractReadValue(
 
   if (templateType === TEMPLATE_TYPE.STRUCTURAL) {
     const data = element.attribs.__transloco;
-    const readSearch = data.match(/read:\s*(['"])(?<read>[^"']*)\1/);
+    const readSearch = data.match(/(?:read|prefix):\s*(['"])(?<read>[^"']*)\1/);
     read = readSearch?.groups?.read;
   }
 
   if (templateType === TEMPLATE_TYPE.NG_TEMPLATE) {
     const attrs = Object.keys(element.attribs);
     const readSearch = attrs.find((attr) =>
-      ['translocoread', '[translocoread]'].includes(attr),
+      ['translocoread', '[translocoread]', 'translocoprefix', '[translocoprefix]'].includes(attr),
     );
     read = readSearch && element.attribs[readSearch].replace(/['"]/g, '');
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/jsverse/transloco-keys-manager/issues/197

## What is the new behavior?
Added support for 'prefix' in comments. I also noticed that prefix is not supported at all. I can do it but will take some time.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
