### PR TITLE
feat: add --scope-provider-functions and --service-names CLI options

### DIFF
--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -94,6 +94,20 @@ export const optionDefinitions = [
     type: String,
     description: 'Where are the main translation files',
   },
+  {
+    name: 'scope-provider-functions',
+    type: String,
+    multiple: true,
+    description:
+      'Additional function names that provide translation scopes (e.g. custom wrappers around provideTranslocoScope)',
+  },
+  {
+    name: 'service-names',
+    type: String,
+    multiple: true,
+    description:
+      'Additional service class names that wrap TranslocoService (e.g. TranslationsService)',
+  },
   { name: 'help', alias: 'h', type: Boolean, description: 'Help me, please!' },
 ];
 

--- a/src/keys-builder/typescript/index.ts
+++ b/src/keys-builder/typescript/index.ts
@@ -21,18 +21,37 @@ import { serviceExtractor } from './service.extractor';
 import { signalExtractor } from './signal.extractor';
 
 export function extractTSKeys(config: Config): ExtractionResult {
-  return extractKeys(config, 'ts', TSExtractor);
+  const serviceNames = config.serviceNames;
+  return extractKeys(config, 'ts', (extractorConfig) =>
+    TSExtractor(extractorConfig, serviceNames),
+  );
 }
 
 const translocoImport = /@(jsverse|ngneat)\/transloco/;
 const translocoKeysManagerImport = /@(jsverse|ngneat)\/transloco-keys-manager/;
-function TSExtractor(config: ExtractorConfig): ScopeMap {
+function TSExtractor(
+  config: ExtractorConfig,
+  serviceNames?: string[],
+): ScopeMap {
   const { file, scopes, defaultValue, scopeToKeys } = config;
   const content = readFile(file);
   const extractors = [];
+  const hasTranslocoImport = translocoImport.test(content);
+  const hasCustomService =
+    serviceNames?.some((name) => content.includes(name)) ?? false;
 
-  if (translocoImport.test(content)) {
-    extractors.push(serviceExtractor, pureFunctionExtractor, signalExtractor);
+  if (hasTranslocoImport) {
+    extractors.push(
+      (ast: Parameters<typeof serviceExtractor>[0]) =>
+        serviceExtractor(ast, serviceNames),
+      pureFunctionExtractor,
+      signalExtractor,
+    );
+  } else if (hasCustomService) {
+    extractors.push(
+      (ast: Parameters<typeof serviceExtractor>[0]) =>
+        serviceExtractor(ast, serviceNames),
+    );
   }
 
   if (translocoKeysManagerImport.test(content)) {

--- a/src/keys-builder/typescript/service.extractor.ts
+++ b/src/keys-builder/typescript/service.extractor.ts
@@ -5,17 +5,27 @@ import ts from 'typescript';
 import { buildKeysFromASTNodes } from './build-keys-from-ast-nodes';
 import { TSExtractorResult } from './types';
 
-function buildInjectFunctionQuery(nodeType: string) {
-  return `${nodeType}:has(CallExpression:has(Identifier[name=inject]):has(Identifier[name=TranslocoService]))`;
+function buildInjectFunctionQuery(nodeType: string, name: string) {
+  return `${nodeType}:has(CallExpression:has(Identifier[name=inject]):has(Identifier[name=${name}]))`;
 }
 
-export function serviceExtractor(ast: SourceFile): TSExtractorResult {
-  const constructorInjection =
-    'Constructor Parameter:has(TypeReference Identifier[name=TranslocoService])';
-  const injectFunction = ['PropertyDeclaration', 'VariableDeclaration'].map(
-    buildInjectFunctionQuery,
+export function serviceExtractor(
+  ast: SourceFile,
+  serviceNames: string[] = [],
+): TSExtractorResult {
+  const allNames = ['TranslocoService', ...serviceNames];
+  const constructorInjections = allNames.map(
+    (name) =>
+      `Constructor Parameter:has(TypeReference Identifier[name=${name}])`,
   );
-  const serviceNameQuery = [constructorInjection, injectFunction].join(',');
+  const injectFunctions = allNames.flatMap((name) =>
+    ['PropertyDeclaration', 'VariableDeclaration'].map((nodeType) =>
+      buildInjectFunctionQuery(nodeType, name),
+    ),
+  );
+  const serviceNameQuery = [...constructorInjections, ...injectFunctions].join(
+    ',',
+  );
   const serviceNameNodes = tsquery(ast, serviceNameQuery);
 
   let result: TSExtractorResult = [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,8 @@ export type Config = {
   unflat: boolean;
   command: 'extract' | 'find';
   fileFormat: FileFormats;
+  scopeProviderFunctions?: string[];
+  serviceNames?: string[];
   /** @internal - Used for ${sourceRoot} interpolation in scopePathMap */
   __sourceRoot?: string;
 };

--- a/src/utils/resolve-config.ts
+++ b/src/utils/resolve-config.ts
@@ -46,7 +46,7 @@ export function resolveConfig(inlineConfig: Partial<Config>): Config {
 
   validateDirectories(mergedConfig);
 
-  updateScopesMap({ input: mergedConfig.input });
+  updateScopesMap({ input: mergedConfig.input, scopeProviderFunctions: mergedConfig.scopeProviderFunctions });
 
   devlog('scopes', 'Scopes', {
     'Scopes map': getScopes().scopeToAlias,

--- a/src/utils/update-scopes-map.ts
+++ b/src/utils/update-scopes-map.ts
@@ -26,7 +26,6 @@ interface ScopeDef {
 type ScopeResolver = (node: Node) => ScopeDef[];
 
 const tokenProviderQuery = `ObjectLiteralExpression:has(PropertyAssignment > Identifier[name=TRANSLOCO_SCOPE]) > PropertyAssignment > Identifier[name=/useValue|useFactory/]`;
-const functionProviderQuery = `CallExpression > Identifier[name=provideTranslocoScope]`;
 
 function stringQueryDef(rootNode: Node) {
   return (
@@ -62,9 +61,17 @@ function objectQueryDef(rootNode: Node) {
 // Order is important, we check if it's an object first, then string
 const scopeValueQueries: ScopeResolver[] = [objectQueryDef, stringQueryDef];
 
-type Options = { input?: string[]; files?: string[] };
+type Options = { input?: string[]; files?: string[]; scopeProviderFunctions?: string[] };
 
-const translocoProvider = /(TRANSLOCO_SCOPE|provideTranslocoScope)/;
+function buildProviderRegex(custom: string[] = []): RegExp {
+  const names = ['TRANSLOCO_SCOPE', 'provideTranslocoScope', ...custom];
+  return new RegExp(`(${names.join('|')})`);
+}
+
+function buildFunctionProviderQuery(custom: string[] = []): string {
+  const names = ['provideTranslocoScope', ...custom];
+  return names.map((n) => `CallExpression > Identifier[name=${n}]`).join(', ');
+}
 
 export function updateScopesMap(
   options: Omit<Options, 'input'>,
@@ -75,11 +82,15 @@ export function updateScopesMap(
 export function updateScopesMap({
   input,
   files,
+  scopeProviderFunctions,
 }: Options): Scopes['aliasToScope'] {
   const tsFiles =
     files || input!.map((path) => normalizedGlob(`${path}/**/*.ts`)).flat();
   // Return only the new scopes (for the plugin)
   const aliasToScope: Record<Alias, Scope> = {};
+
+  const translocoProvider = buildProviderRegex(scopeProviderFunctions);
+  const dynamicFunctionProviderQuery = buildFunctionProviderQuery(scopeProviderFunctions);
 
   for (const file of tsFiles) {
     const content = readFile(file);
@@ -92,7 +103,7 @@ export function updateScopesMap({
 
     const tokenAndProviderNodes = tsquery(
       ast,
-      `${tokenProviderQuery}, ${functionProviderQuery}`,
+      `${tokenProviderQuery}, ${dynamicFunctionProviderQuery}`,
     );
 
     for (let node of tokenAndProviderNodes) {

--- a/src/webpack-plugin/webpack-plugin.ts
+++ b/src/webpack-plugin/webpack-plugin.ts
@@ -50,7 +50,7 @@ export class TranslocoExtractKeysWebpackPlugin {
           let tsResult = initExtraction();
           if (keysExtractions.ts.length) {
             // Maybe someone added a TRANSLOCO_SCOPE
-            const newScopes = updateScopesMap({ files: keysExtractions.ts });
+            const newScopes = updateScopesMap({ files: keysExtractions.ts, scopeProviderFunctions: this.config.scopeProviderFunctions });
 
             const paths = buildScopeFilePaths({
               aliasToScope: newScopes,


### PR DESCRIPTION
Adds support for custom wrapper function names around provideTranslocoScope and TranslocoService, enabling TKM to work with projects that use custom abstractions over the standard Transloco APIs.

In our NX monorepo we wrap transloco in our own shared translations service in order to enforce some conventions and make future refactoring easier. This will enable us to do that and still use the keys manager to enforce rules on missing and extra keys.

--scope-provider-functions: Additional function names that provide translation scopes (e.g. provideScopedTranslations).

--service-names: Additional service class names that wrap TranslocoService (e.g. TranslationsService). Also fixes the import path gate so the service extractor runs for files that import custom services from non-standard paths.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

Additional options for the keys-manager CLI

- [x] Feature

## What is the current behavior?

keys-manager will look for `TRANSLOCO_SCOPE` or `provideTranslocoScope` 

Issue Number: N/A

## What is the new behavior?

Only provideTranslocoScope, TRANSLOCO_SCOPE, and TranslocoService are recognized for scope detection and key extraction.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I apologize beforehand that this PR was written mostly via Claude Code while testing the transloco keys manager in my monorepo to achieve the desired results. I did not get familiar enough with the codebase to be able to make very opinionated decisions on design so I hope this is not a totally insane solution to just add this as options to the CLI.