### PR TITLE
fix: replace instanceof type guards with constructor.name checks

### DIFF
--- a/src/keys-builder/template/directive.extractor.ts
+++ b/src/keys-builder/template/directive.extractor.ts
@@ -23,9 +23,11 @@ import {
   parseTemplate,
   resolveBlockChildNodes,
   resolveKeysFromLiteralMap,
+  isConditionalExpression,
+  isLiteralExpression,
+  isLiteralMap,
 } from './utils';
 import { coerceArray } from '../../utils/collection.utils';
-import { isConditionalExpression, isLiteralExpression, isLiteralMap } from '@jsverse/angular-utils';
 import { isString, notNil } from '../../utils/validators.utils';
 
 export function directiveExtractor(config: TemplateExtractorConfig) {

--- a/src/keys-builder/template/pipe.extractor.ts
+++ b/src/keys-builder/template/pipe.extractor.ts
@@ -11,18 +11,18 @@ import { addKey } from '../add-key';
 import { resolveAliasAndKey } from '../utils/resolvers.utils';
 
 import { TemplateExtractorConfig } from './types';
-import { parseTemplate, resolveKeysFromLiteralMap } from './utils';
-import { notNil } from '../../utils/validators.utils';
-import { coerceArray } from '../../utils/collection.utils';
-
 import {
-  AstPipeCollector,
+  parseTemplate,
+  resolveKeysFromLiteralMap,
   isBindingPipe,
   isConditionalExpression,
   isLiteralExpression,
   isLiteralMap,
-  TmplPipeCollector,
-} from '@jsverse/angular-utils';
+} from './utils';
+import { notNil } from '../../utils/validators.utils';
+import { coerceArray } from '../../utils/collection.utils';
+
+import { AstPipeCollector, TmplPipeCollector } from '@jsverse/angular-utils';
 
 export function pipeExtractor(config: TemplateExtractorConfig) {
   const parsedTemplate = parseTemplate(config);

--- a/src/keys-builder/template/structural-directive.extractor.ts
+++ b/src/keys-builder/template/structural-directive.extractor.ts
@@ -29,8 +29,10 @@ import {
   isBlockNode,
   resolveBlockChildNodes,
   resolveKeysFromLiteralMap,
+  isConditionalExpression,
+  isLiteralExpression,
+  isLiteralMap,
 } from './utils';
-import { isConditionalExpression, isLiteralExpression, isLiteralMap } from '@jsverse/angular-utils';
 import { isString } from '../../utils/validators.utils';
 
 interface MethodCallMetadata {

--- a/src/keys-builder/template/utils.ts
+++ b/src/keys-builder/template/utils.ts
@@ -1,9 +1,12 @@
 import {
+  BindingPipe,
   Call,
+  Conditional,
   Interpolation,
   LiteralMap,
   LiteralMapKey,
   LiteralMapPropertyKey,
+  LiteralPrimitive,
   parseTemplate as ngParseTemplate,
   ParseTemplateOptions,
   PropertyRead,
@@ -28,7 +31,6 @@ import {
 import { readFile } from '../../utils/file.utils';
 
 import { TemplateExtractorConfig } from './types';
-import { isLiteralMap } from '@jsverse/angular-utils';
 
 export function isTemplate(node: unknown): node is TmplAstTemplate {
   return node instanceof TmplAstTemplate;
@@ -179,6 +181,22 @@ export function resolveBlockChildNodes(node: BlockNode): TmplAstNode[] {
   }
 
   return node.children;
+}
+
+export function isLiteralExpression(ast: unknown): ast is LiteralPrimitive {
+  return (ast as any)?.constructor?.name === 'LiteralPrimitive';
+}
+
+export function isConditionalExpression(ast: unknown): ast is Conditional {
+  return (ast as any)?.constructor?.name === 'Conditional';
+}
+
+export function isLiteralMap(ast: unknown): ast is LiteralMap {
+  return (ast as any)?.constructor?.name === 'LiteralMap';
+}
+
+export function isBindingPipe(ast: unknown): ast is BindingPipe {
+  return (ast as any)?.constructor?.name === 'BindingPipe';
 }
 
 export function resolveKeysFromLiteralMap(node: LiteralMap): string[] {


### PR DESCRIPTION
Apologies again for this fix, it was a solution cooked up with Claude Code as well, and I am less sure that this is the right fix for this issue.

What I am trying to solve it getting the keys detective to give me the extra/missing keys in my NX monorepo setup, related to this PR #249 

Below is written by Claude since I don't know exactly the problem that was being fixed, apologies again, I don't have as much time as I would like to contribute by getting more familiar with the codebase

---

In NX monorepos where the project's Angular version differs from what TKM bundles, @angular/compiler gets installed twice. The instanceof-based type guards from @jsverse/angular-utils always return false because the AST nodes and class constructors come from different module copies.

Replace all @jsverse/angular-utils type guard imports with local implementations using constructor.name string comparison. This is safe because TKM runs in Node.js (no minification) and Angular compiler class names are stable public API.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

Template extraction silently produces zero keys when multiple copies of `@angular/compiler` exist in the dependency tree (common in NX monorepos).

The `instanceof`-based type guards imported from `@jsverse/angular-utils` always return `false` because the AST nodes produced by TKM's `parseTemplate()` come from TKM's bundled `@angular/compiler`, while `angular-utils` resolves to the project-level copy.

Issue Number: N/A

## What is the new behavior?

The four type guards (`isLiteralExpression`, `isConditionalExpression`, `isLiteralMap`, `isBindingPipe`) are reimplemented locally using `constructor.name` string comparison, which works across module copies. `AstPipeCollector` and `TmplPipeCollector` are kept from `angular-utils` as they use the visitor pattern, not `instanceof`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is a workaround for the `instanceof` cross-copy issue. A more permanent fix could be made in `@jsverse/angular-utils` itself by switching its type guards to the same `constructor.name` approach. `constructor.name` is safe here because TKM runs in Node.js (no minification) and Angular compiler class names are stable public API.
