### PR TITLE
fix: 🐛 exit with a non-zero code when a configured path is invalid

### DIFF
--- a/__tests__/resolveConfig/resolveConfig.spec.ts
+++ b/__tests__/resolveConfig/resolveConfig.spec.ts
@@ -132,7 +132,7 @@ describe('resolveConfig', () => {
   describe('validate directories', () => {
     function shouldFail(prop: string, msg: 'pathDoesntExist' | 'pathIsNotDir') {
       const [processExitSpy, consoleLogSpy] = spies;
-      expect(processExitSpy).toHaveBeenCalled();
+      expect(processExitSpy).toHaveBeenCalledWith(1);
       expect(consoleLogSpy).toHaveBeenCalledWith(
         chalk.bgRed.black(`${prop} ${messages[msg]}`),
       );
@@ -179,6 +179,15 @@ describe('resolveConfig', () => {
         command: 'find',
       });
       shouldFail('Translations', 'pathIsNotDir');
+    });
+
+    it('should exit with a non-zero code so CI fails (issue #217)', () => {
+      const [processExitSpy] = spies;
+      resolveConfig({ input: ['noFolder'] });
+      const [exitCode] = processExitSpy.mock.calls.at(-1)!;
+      expect(exitCode).not.toBe(0);
+      expect(exitCode).toBeDefined();
+      clearSpies();
     });
   });
 

--- a/src/utils/resolve-config.ts
+++ b/src/utils/resolve-config.ts
@@ -97,5 +97,5 @@ function validateDirectories({ input, translationsPath, command }: Config) {
     log(translationsPath, 'Translations');
   }
 
-  invalidPath && process.exit();
+  invalidPath && process.exit(1);
 }


### PR DESCRIPTION
## Problem

`validateDirectories` ended with:

```ts
invalidPath && process.exit();
```

`process.exit()` with no argument exits with code **0**. So whenever the input or translations path could not be resolved, TKM printed its red error banner and then told the shell it had succeeded:

```console
$ transloco-keys-manager find --input does-not-exist --emit-error-on-extra-keys
Input path provided doesn't exist!
$ echo $?
0
```

In CI this is the worst possible outcome — a misconfigured run is indistinguishable from a clean one, so the step stays green and no keys are ever actually validated.

This is the first of the bugs found while digging into jsverse/transloco#973. The reporter there ran `find --emit-error-on-extra-keys`, hit `Input path provided doesn't exist!`, and got exit 0 — which is exactly the "no error when `--emit-error-on-extra-keys` is passed" they reported. (The second bug in that issue, `extract` silently ignoring `--emit-error-on-extra-keys`, is not addressed here and stays open.)

## Fix

Exit with code `1`.

I kept `1` rather than introducing a new code: `1` and `2` are already the keys-detective contract for missing/extra keys, and a configuration error is a generic failure. The distinction that matters to CI — zero vs. non-zero — is now correct. Happy to switch to a dedicated code if you'd rather config errors be separately detectable.

The help-menu `process.exit()` in `src/index.ts` is intentionally left alone; exiting 0 after printing help is correct.

## Why this wasn't caught

The directory-validation tests asserted only that `process.exit` had been *called*:

```ts
expect(processExitSpy).toHaveBeenCalled();
```

never with which code. That passes just as happily for `exit()` as for `exit(1)`. They now assert `toHaveBeenCalledWith(1)`, plus one explicitly-named regression test for the non-zero property.

I verified the tests fail against the unfixed source (4 failures, including `expected undefined to be defined` — i.e. `exit` called with no argument) and pass with the fix.

## Verification

Full suite: **174 passed / 17 files**.

Against a built `dist`:

| command | exit code |
|---|---|
| `find --input does-not-exist` | 1 ✅ (was 0) |
| `find --translations-path nope` | 1 ✅ (was 0) |
| `extract` (valid config) | 0 ✅ |
| `--help` | 0 ✅ |

## Note on behaviour change

This is a behaviour change for anyone whose pipeline currently tolerates a misconfigured TKM invocation — those builds will start failing. That's the point of the fix, but it's worth a line in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation now exits with status code `1` when input or translation paths are invalid.
  * Improved reliability of CI checks for configurations with missing input paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->