### PR TITLE
fix: 🐛 keep translations when removing extra keys from a nested file

### DIFF
--- a/__tests__/buildTranslationFiles/config-options/remove-extra-keys/remove-extra-keys-spec.ts
+++ b/__tests__/buildTranslationFiles/config-options/remove-extra-keys/remove-extra-keys-spec.ts
@@ -6,10 +6,11 @@ import {
   TranslationTestCase,
 } from '../../build-translation-utils';
 import { mockResolveProjectBasePath } from '../../../spec-utils';
+import { getCurrentTranslation } from '../../../../src/keys-builder/utils/get-current-translation';
 import { Config, Translation } from '../../../../src/types';
 import fs from 'fs-extra';
 import nodePath from 'node:path';
-import { afterEach, beforeEach, describe, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 mockResolveProjectBasePath(sourceRoot);
 
@@ -131,5 +132,53 @@ export function testRemoveExtraKeysConfig(fileFormat: Config['fileFormat']) {
         },
       });
     });
+
+    /**
+     * A nested file on disk with `unflat = false` means the extracted keys are
+     * flat while the current translation is not. The extra keys cleanup used to
+     * read every nested key as extra and wipe the whole file, translations of
+     * keys that are still in use included.
+     */
+    describe.runIf(fileFormat === 'json')(
+      'with a nested translation file and unflat = false',
+      () => {
+        const enPath = nodePath.join(
+          sourceRoot,
+          type,
+          'i18n',
+          `en.${fileFormat}`,
+        );
+
+        it('should drop only the extra keys and keep the existing translations', () => {
+          fs.copyFileSync(missingKeyTpl, testHtmlFile);
+          fs.outputJsonSync(enPath, {
+            '1': 'translated 1',
+            '2': 'translated 2',
+            group1: { '2': 'translated group1.2' },
+            group2: { '1': 'translated group2.1' },
+            group3: { '2': 'translated group3.2' },
+          });
+
+          buildTranslationFiles({
+            ...buildConfig({ type, config: { unflat: false, fileFormat } }),
+            removeExtraKeys: true,
+          });
+
+          const translation = getCurrentTranslation({
+            path: enPath,
+            fileFormat,
+          });
+
+          expect(translation).toMatchObject({
+            '2': 'translated 2',
+            group1: { '2': 'translated group1.2' },
+            group3: { '2': 'translated group3.2' },
+          });
+          // `1` and the whole `group2` are no longer used
+          expect(translation).not.toHaveProperty('1');
+          expect(translation).not.toHaveProperty('group2');
+        });
+      },
+    );
   });
 }

--- a/__tests__/remove-extra-keys.spec.ts
+++ b/__tests__/remove-extra-keys.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { removeExtraKeys } from '../src/keys-builder/utils/remove-extra-keys';
+
+describe('removeExtraKeys', () => {
+  describe('when both sides share the same shape', () => {
+    it('should keep used keys and drop extra ones from a flat translation', () => {
+      const current = { 'a.b': 'translated a.b', 'x.y': 'stale' };
+      const extracted = { 'a.b': 'missing' };
+
+      expect(removeExtraKeys(current, extracted)).toEqual({
+        'a.b': 'translated a.b',
+      });
+    });
+
+    it('should keep used keys and drop extra ones from a nested translation', () => {
+      const current = {
+        a: { b: 'translated a.b' },
+        x: { y: 'stale' },
+      };
+      const extracted = { a: { b: 'missing' } };
+
+      expect(removeExtraKeys(current, extracted)).toEqual({
+        a: { b: 'translated a.b' },
+      });
+    });
+  });
+
+  /**
+   * `currentTranslation` is read from disk as-is, while the extracted keys are
+   * flat unless `unflat` is on. When the two shapes disagree, every key used to
+   * look extra and the whole file was wiped.
+   */
+  describe('when the shapes disagree', () => {
+    it('should resolve a nested translation against flat extracted keys', () => {
+      const current = {
+        used: { key: 'translated value' },
+        totally: { extra: 'stale' },
+      };
+      const extracted = { 'used.key': 'missing' };
+
+      expect(removeExtraKeys(current, extracted)).toEqual({
+        used: { key: 'translated value' },
+      });
+    });
+
+    it('should resolve a flat translation against nested extracted keys', () => {
+      const current = {
+        'used.key': 'translated value',
+        'totally.extra': 'stale',
+      };
+      const extracted = { used: { key: 'missing' } };
+
+      expect(removeExtraKeys(current, extracted)).toEqual({
+        'used.key': 'translated value',
+      });
+    });
+
+    it('should keep a partially nested translation intact', () => {
+      const current = {
+        'a.b': 'translated a.b',
+        c: { d: 'translated c.d' },
+        gone: { away: 'stale' },
+      };
+      const extracted = { 'a.b': 'missing', 'c.d': 'missing' };
+
+      expect(removeExtraKeys(current, extracted)).toEqual({
+        'a.b': 'translated a.b',
+        c: { d: 'translated c.d' },
+      });
+    });
+  });
+});

--- a/src/keys-builder/utils/remove-extra-keys.ts
+++ b/src/keys-builder/utils/remove-extra-keys.ts
@@ -1,24 +1,48 @@
+import { flatten } from 'flat';
+
 import { isObject } from '../../utils/validators.utils';
 import { Translation } from '../../types';
 
+/**
+ * The current translation is read from disk as-is, while the extracted keys are
+ * flat unless `unflat` is on, so the two can disagree on shape. Comparing the
+ * flattened key paths keeps the check independent of both shapes, the same way
+ * the keys detective does it.
+ */
 export function removeExtraKeys(
   currentTranslation: Translation,
   extractedTranslation: Translation,
 ): Translation {
+  const extractedPaths = new Set(
+    Object.keys(
+      flatten<Translation, Record<string, string>>(extractedTranslation, {
+        safe: true,
+      }),
+    ),
+  );
+
+  return resolveUsedKeys(currentTranslation, extractedPaths);
+}
+
+function resolveUsedKeys(
+  currentTranslation: Translation,
+  extractedPaths: Set<string>,
+  prefix = '',
+): Translation {
   const resolved: Translation = {};
 
   for (const key in currentTranslation) {
-    if (!extractedTranslation.hasOwnProperty(key)) {
-      continue;
-    }
+    const path = prefix ? `${prefix}.${key}` : key;
+    const value = currentTranslation[key];
 
-    if (isObject(currentTranslation[key])) {
-      resolved[key] = removeExtraKeys(
-        currentTranslation[key],
-        extractedTranslation[key],
-      );
-    } else {
-      resolved[key] = currentTranslation[key];
+    if (isObject(value)) {
+      const nested = resolveUsedKeys(value, extractedPaths, path);
+
+      if (Object.keys(nested).length > 0) {
+        resolved[key] = nested;
+      }
+    } else if (extractedPaths.has(path)) {
+      resolved[key] = value;
     }
   }
 


### PR DESCRIPTION
## Symptom

`extract --remove-extra-keys` destroys translation data when the translation file on disk is **nested** and `unflat` is falsy (the default). It does not just drop the unused keys — it replaces the translations of keys that are still in use with the default placeholder.

The clearest way to see it is a file where **nothing is extra**, so the flag has no work to do. Template:

```html
<h1>{{ 'home.title' | transloco }}</h1>
<p>{{ 'home.subtitle' | transloco }}</p>
<button>{{ 'actions.save' | transloco }}</button>
```

`en.json` — every key in it is in use:

```json
{
  "home": { "title": "Welcome", "subtitle": "Glad you're here" },
  "actions": { "save": "Save" }
}
```

`extract --remove-extra-keys` returned:

```json
{
  "home.title": "Missing value for 'home.title'",
  "home.subtitle": "Missing value for 'home.subtitle'",
  "actions.save": "Missing value for 'actions.save'"
}
```

There were no extra keys to remove, so this should have been a no-op. Instead all three translations are gone. Exit code 0, no warning.

After the fix, the translations survive and the output is byte-identical to a plain `extract` on the same input — i.e. the flag is correctly a no-op when nothing is extra.

## Root cause

`removeExtraKeys` walked the two objects one nesting level at a time and asked `extractedTranslation.hasOwnProperty(key)` at each level, which only works if both sides share the same shape. They don't:

- `currentTranslation` comes off disk as-is — `get-current-translation.ts` → `parseJson` → `fs.readJsonSync`, no flattening. It keeps whatever shape the file has.
- `translation` (the extracted keys) is always **flat**, unless `unflat` is on — `createJson` unflattens it just before `resolveTranslation` (`create-translation.ts:40-42`).

So with a nested file and `unflat: false`, the top level keys are `used` / `totally` while the extracted keys are `used.key`. Nothing matched, every subtree was treated as extra, and the file was emptied.

## Evidence

A second fixture, this one *with* a genuinely extra key, to confirm the flag still does its job. The template uses `used.key`, and `en.json` is:

```json
{
  "used": { "key": "translated value" },
  "totally": { "extra": "I am an extra key" }
}
```

`totally.extra` is unused and should be removed; `used.key` is in use and its translation must survive. Across the four shape/flag combinations:

| case | file shape | `unflat` | `-R` | before | after |
|---|---|---|---|---|---|
| A | nested | `false` (default) | ✅ | **`{"used.key": "Missing value for 'used.key'"}`** — wiped | `{"used": {"key": "translated value"}}` kept, `totally.extra` removed |
| B | nested | `true` | ✅ | correct | unchanged |
| C | nested | `false` (default) | ❌ | nested content preserved, duplicated flat key appended | unchanged |
| D | flat | `false` (default) | ✅ | correct | unchanged |

Case C matters twice over: it shows the data loss is specific to `--remove-extra-keys` rather than to `extract` in general, and it is deliberately left alone here (see below).

`find` gets this right on the identical case-A input — it reports exactly one extra key, `totally.extra` — because `compare-keys-to-files.ts:114-121` flattens the file with `flatten(translation, { safe: true })` before diffing. That is the reference behavior this change adopts: **`find` is the source of truth for extra-key semantics.**

## The fix

`removeExtraKeys` now flattens the *extracted* keys once into a set of paths, then walks the current translation carrying the path prefix, keeping a leaf only when its flattened path is in that set. The comparison becomes shape-independent while the output preserves the shape of the file on disk.

Uses `flatten(..., { safe: true })` to match how the detective does it.

## Tests

`__tests__/remove-extra-keys.spec.ts` (new, 5 unit tests):

- both sides flat, and both sides nested — the paths that already worked, as regression guards
- nested current vs flat extracted (the bug)
- flat current vs nested extracted (the mirror image)
- partially nested current vs flat extracted

`__tests__/buildTranslationFiles/config-options/remove-extra-keys/remove-extra-keys-spec.ts`: an end-to-end case seeding a nested file with `unflat: false`, asserting the in-use nested translations survive and that the unused key and unused group are gone. Scoped to `json` via `describe.runIf` — `pot` cannot represent nesting.

The existing suite only covered `unflat: true` (both sides nested) and `unflat: false` (both sides flat). The mismatch combination was the untested gap, which is why this survived.

Full suite: **180 passed, 1 skipped** (the skip is the `pot` variant of the new case). Baseline before the change was 174 passed. No existing test had encoded the buggy behavior, so none were rewritten.

## Deliberately out of scope

Two related findings I did **not** change, both worth a maintainer decision:

1. **Case C duplication.** With a nested file and `unflat: false`, `mergeDeep({}, translation, currentTranslation)` merges flat extracted keys into a nested current translation and produces both spellings (`"used.key"` alongside `"used": { "key": ... }"`). Same underlying shape mismatch, but fixing it changes output for users who don't pass `-R` at all, so it is a wider behavioral change than this bug. It is pre-existing and unaffected either way by this PR.

2. **`.comment` keys.** `find` deliberately excludes `*.comment` keys from the extra list (`compare-keys-to-files.ts:138`) to support the translator-note convention. `removeExtraKeys` has no such exclusion, so `extract --remove-extra-keys` deletes them. Verified divergence. Aligning it with `find` would be consistent with treating `find` as the source of truth, but it changes what the flag deletes, so I left it for you to call.

## Not a fix for jsverse/transloco#973

jsverse/transloco#973 is that `extract` silently accepts and ignores `--emit-error-on-extra-keys`. This PR does not address that — hence `Related: jsverse/transloco#973` rather than `Closes`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved removal of unused translation keys, including nested and partially nested structures.
  * Preserved valid translations when current and extracted files use different key shapes.
  * Ensured only keys with matching full paths are retained.

* **Tests**
  * Added coverage for flat, nested, mixed-shape, and JSON translation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
