### PR TITLE
feat: 🎸 warn when an option is not supported by the invoked command

### DIFF
--- a/__tests__/logger.spec.ts
+++ b/__tests__/logger.spec.ts
@@ -18,12 +18,24 @@ describe('logger', () => {
   });
 
   describe('getLogger', () => {
-    it('should return a logger with log, success, and startSpinner methods', async () => {
+    it('should return a logger with log, warn, success, and startSpinner methods', async () => {
       const { getLogger } = await import('../src/utils/logger');
       const logger = getLogger();
       expect(logger).toHaveProperty('log');
+      expect(logger).toHaveProperty('warn');
       expect(logger).toHaveProperty('success');
       expect(logger).toHaveProperty('startSpinner');
+    });
+
+    it('should write warnings to stderr through console.warn', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { getLogger } = await import('../src/utils/logger');
+      getLogger().warn('something is off');
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('something is off'),
+      );
     });
   });
 

--- a/__tests__/messages.spec.ts
+++ b/__tests__/messages.spec.ts
@@ -30,6 +30,21 @@ describe('messages', () => {
     );
   });
 
+  it('should use singular wording for a single unsupported option', () => {
+    expect(messages.unsupportedOptions('extract', ['--output'])).toBe(
+      '--output is not supported by the "extract" command and was ignored. This will throw an error in the next major version.',
+    );
+  });
+
+  it('should use plural wording for several unsupported options', () => {
+    const result = messages.unsupportedOptions('find', [
+      '--output',
+      '--replace',
+    ]);
+    expect(result).toContain('--output, --replace are not supported');
+    expect(result).toContain('were ignored');
+  });
+
   it('should format problematic keys for unflat', () => {
     const result = messages.problematicKeysForUnflat(['a.b', 'a.b.c']);
     expect(result).toContain('"a.b"');

--- a/__tests__/warn-unsupported-options.spec.ts
+++ b/__tests__/warn-unsupported-options.spec.ts
@@ -138,16 +138,33 @@ describe('commandSpecificOptions', () => {
     ).toEqual([]);
   });
 
-  it('should not hold options that no longer exist', () => {
-    const definedOptions = optionDefinitions.map(({ name }) => camelCase(name));
-
-    const stale = Object.keys(commandSpecificOptions).filter(
-      (option) => !definedOptions.includes(option),
+  /**
+   * An option listed in both places passes the check above, which would let a
+   * later deletion from `commandSpecificOptions` go unnoticed: the option stops
+   * warning while `sharedOptions` keeps it looking classified.
+   */
+  it('should not classify an option as both command specific and shared', () => {
+    const overlapping = Object.keys(commandSpecificOptions).filter((option) =>
+      sharedOptions.includes(option),
     );
 
     expect(
+      overlapping,
+      'The option is both command specific and shared, remove it from one of the two',
+    ).toEqual([]);
+  });
+
+  it('should not classify options that no longer exist', () => {
+    const definedOptions = optionDefinitions.map(({ name }) => camelCase(name));
+
+    const stale = [
+      ...Object.keys(commandSpecificOptions),
+      ...sharedOptions,
+    ].filter((option) => !definedOptions.includes(option));
+
+    expect(
       stale,
-      '`commandSpecificOptions` holds a renamed or removed option, so nothing warns about it anymore',
+      'The option was renamed or removed, drop it from `commandSpecificOptions` or from `sharedOptions`. A leftover key in the former warns about nothing',
     ).toEqual([]);
   });
 });

--- a/__tests__/warn-unsupported-options.spec.ts
+++ b/__tests__/warn-unsupported-options.spec.ts
@@ -1,0 +1,99 @@
+import commandLineArgs from 'command-line-args';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { optionDefinitions } from '../src/cli-options';
+import { warnUnsupportedOptions } from '../src/utils/warn-unsupported-options';
+import { spyOnConsole } from './spec-utils';
+
+describe('warnUnsupportedOptions', () => {
+  let warnSpy: ReturnType<typeof spyOnConsole>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    warnSpy = spyOnConsole('warn');
+  });
+
+  it('should warn when a detective only option is passed to extract', () => {
+    warnUnsupportedOptions('extract', { emitErrorOnExtraKeys: true });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('--emit-error-on-extra-keys');
+    expect(warnSpy.mock.calls[0][0]).toContain('extract');
+  });
+
+  it('should warn when an extractor only option is passed to find', () => {
+    warnUnsupportedOptions('find', { removeExtraKeys: true });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('--remove-extra-keys');
+    expect(warnSpy.mock.calls[0][0]).toContain('find');
+  });
+
+  it('should list every unsupported option in a single warning', () => {
+    warnUnsupportedOptions('find', {
+      output: 'i18n',
+      replace: true,
+      removeExtraKeys: true,
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [message] = warnSpy.mock.calls[0];
+    expect(message).toContain('--output');
+    expect(message).toContain('--replace');
+    expect(message).toContain('--remove-extra-keys');
+  });
+
+  it('should announce the upcoming breaking change', () => {
+    warnUnsupportedOptions('extract', { addMissingKeys: true });
+
+    expect(warnSpy.mock.calls[0][0]).toContain('next major version');
+  });
+
+  it('should stay silent when the command supports every option', () => {
+    warnUnsupportedOptions('extract', {
+      removeExtraKeys: true,
+      replace: true,
+      output: 'i18n',
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * `defaultValue` and `sort` are documented as extractor options, but both
+   * commands run the same extraction pipeline, so they change what `find`
+   * writes with `--add-missing-keys`. Warning about them would be wrong.
+   */
+  it('should not warn for options both commands read', () => {
+    warnUnsupportedOptions('find', {
+      defaultValue: 'missing',
+      sort: true,
+      unflat: true,
+      langs: ['en'],
+      marker: 't',
+      fileFormat: 'json',
+      translationsPath: 'i18n',
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The warning must only fire for options typed on the CLI. A single
+   * `transloco.config.js` legitimately serves both commands, and
+   * `command-line-args` omits options that weren't passed - that absence is
+   * the whole provenance mechanism, so lock it in.
+   */
+  it('should ignore options that were not passed on the CLI', () => {
+    const parsed = commandLineArgs(optionDefinitions, {
+      camelCase: true,
+      argv: ['--sort'],
+    });
+
+    expect('emitErrorOnExtraKeys' in parsed).toBe(false);
+
+    warnUnsupportedOptions('extract', parsed);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/warn-unsupported-options.spec.ts
+++ b/__tests__/warn-unsupported-options.spec.ts
@@ -1,9 +1,34 @@
 import commandLineArgs from 'command-line-args';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { optionDefinitions } from '../src/cli-options';
+import { commandSpecificOptions, optionDefinitions } from '../src/cli-options';
 import { warnUnsupportedOptions } from '../src/utils/warn-unsupported-options';
 import { spyOnConsole } from './spec-utils';
+
+/**
+ * The options both commands read, spelled out so `commandSpecificOptions` can't
+ * silently miss a new flag: an option that is neither classified there nor
+ * listed here fails the tests below, which forces the call to be made when the
+ * flag is added instead of after a bug report.
+ */
+const sharedOptions = [
+  'project',
+  'config',
+  'input',
+  'langs',
+  'fileFormat',
+  'marker',
+  'sort',
+  'unflat',
+  'defaultValue',
+  'translationsPath',
+  'help',
+];
+
+/** Mirrors the camelCasing `commandLineArgs` applies to the option names. */
+function camelCase(option: string) {
+  return option.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+}
 
 describe('warnUnsupportedOptions', () => {
   let warnSpy: ReturnType<typeof spyOnConsole>;
@@ -95,5 +120,34 @@ describe('warnUnsupportedOptions', () => {
     warnUnsupportedOptions('extract', parsed);
 
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('commandSpecificOptions', () => {
+  it('should classify every CLI option as command specific or shared', () => {
+    const unclassified = optionDefinitions
+      .map(({ name }) => camelCase(name))
+      .filter(
+        (option) =>
+          !commandSpecificOptions[option] && !sharedOptions.includes(option),
+      );
+
+    expect(
+      unclassified,
+      'Add the option to `commandSpecificOptions` if a single command reads it, otherwise to `sharedOptions` in this spec',
+    ).toEqual([]);
+  });
+
+  it('should not hold options that no longer exist', () => {
+    const definedOptions = optionDefinitions.map(({ name }) => camelCase(name));
+
+    const stale = Object.keys(commandSpecificOptions).filter(
+      (option) => !definedOptions.includes(option),
+    );
+
+    expect(
+      stale,
+      '`commandSpecificOptions` holds a renamed or removed option, so nothing warns about it anymore',
+    ).toEqual([]);
   });
 });

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -1,3 +1,5 @@
+import { Config } from './types';
+
 export const optionDefinitions = [
   {
     name: 'project',
@@ -96,6 +98,22 @@ export const optionDefinitions = [
   },
   { name: 'help', alias: 'h', type: Boolean, description: 'Help me, please!' },
 ];
+
+/**
+ * The options only one of the commands reads, keyed by the camelCased name
+ * `commandLineArgs` produces. Anything missing here is shared.
+ *
+ * Note that `default-value` and `sort` look like extractor options but are not:
+ * both commands run the same extraction pipeline, so they change what `find`
+ * writes with `--add-missing-keys`.
+ */
+export const commandSpecificOptions: Record<string, Config['command']> = {
+  output: 'extract',
+  replace: 'extract',
+  removeExtraKeys: 'extract',
+  addMissingKeys: 'find',
+  emitErrorOnExtraKeys: 'find',
+};
 
 export const sections = [
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { optionDefinitions, sections } from './cli-options';
 import { buildTranslationFiles } from './keys-builder';
 import { findMissingKeys } from './keys-detective';
 import { Config } from './types';
+import { warnUnsupportedOptions } from './utils/warn-unsupported-options';
 
 const mainDefinitions = [{ name: 'command', defaultOption: true }];
 
@@ -34,8 +35,10 @@ const resolvedConfig = {
 } as Config;
 
 if (resolvedConfig.command === 'extract') {
+  warnUnsupportedOptions('extract', config);
   buildTranslationFiles(resolvedConfig);
 } else if (resolvedConfig.command === 'find') {
+  warnUnsupportedOptions('find', config);
   findMissingKeys(resolvedConfig);
 } else {
   console.log(`Please provide an action...`);

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -20,6 +20,12 @@ export const messages = {
   addMissing: 'Add missing keys automatically?',
   missingValue: 'Missing value for',
   done: 'Done!',
+  unsupportedOptions: (command: string, flags: string[]) =>
+    `${flags.join(', ')} ${
+      flags.length > 1 ? 'are' : 'is'
+    } not supported by the "${command}" command and ${
+      flags.length > 1 ? 'were' : 'was'
+    } ignored. This will throw an error in the next major version.`,
   problematicKeysForUnflat: (keys: string[]) =>
     `The following keys won't be accessible when unflatting the object:\n ${keys
       .map((k) => `"${k}"`)

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -8,6 +8,7 @@ function noop() {}
 const isProd = process.env.PRODUCTION;
 const defaultLogger = {
   log: (...msg: string[]) => (isProd ? noop : console.log(...msg)),
+  warn: (msg: string) => (isProd ? noop : console.warn(`⚠️  ${msg}`)),
   success: (msg: string) => (isProd ? noop : spinner.succeed(msg)),
   startSpinner: (msg: string) => (isProd ? noop : (spinner = ora().start(msg))),
 };

--- a/src/utils/warn-unsupported-options.ts
+++ b/src/utils/warn-unsupported-options.ts
@@ -1,0 +1,35 @@
+import { commandSpecificOptions } from '../cli-options';
+import { messages } from '../messages';
+import { Config } from '../types';
+
+import { getLogger } from './logger';
+
+/**
+ * Warns about options the invoked command doesn't read.
+ *
+ * `cliOptions` must be the raw `commandLineArgs` result and not the resolved
+ * config: options that weren't passed are missing from it entirely, which is
+ * what tells us the user typed the flag for *this* command. The same key coming
+ * from `transloco.config.js` is legitimate, since one config file serves both
+ * commands, so it has to stay silent.
+ */
+export function warnUnsupportedOptions(
+  command: Config['command'],
+  cliOptions: Record<string, unknown>,
+) {
+  const unsupported = Object.keys(cliOptions).filter(
+    (option) =>
+      commandSpecificOptions[option] &&
+      commandSpecificOptions[option] !== command,
+  );
+
+  if (unsupported.length === 0) return;
+
+  getLogger().warn(
+    messages.unsupportedOptions(command, unsupported.map(toFlag)),
+  );
+}
+
+function toFlag(option: string) {
+  return `--${option.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`)}`;
+}


### PR DESCRIPTION
## Problem

`optionDefinitions` is one flat list shared by both commands, and `src/index.ts` parses it once before dispatching. There is no per-command schema, so every flag parses for every command and the unsupported ones are silently ignored.

`--emit-error-on-extra-keys` has been accepted-and-ignored by `extract` since jsverse/transloco-keys-manager#39 (2020) — only the keys detective ever reads it. That silence is what jsverse/transloco#973 reported: users reasonably read `--remove-extra-keys` and `--emit-error-on-extra-keys` as a pair, pass both to `extract`, and get no feedback that half of what they typed does nothing.

## Solution

Warn on stderr when an option is passed **on the command line** to a command that does not read it.

```
$ transloco-keys-manager extract --emit-error-on-extra-keys
⚠️  --emit-error-on-extra-keys is not supported by the "extract" command and was ignored. This will throw an error in the next major version.
```

**Exit codes are untouched.** This is the warning half of a two-stage deprecation — every comparable tool (git, docker, cargo, tsc, eslint) hard-errors on a flag the subcommand does not support, and npm, the lenient outlier, is migrating there via exactly this staged wording. Given 8.x has already moved exit codes twice (#257, jsverse/transloco-keys-manager#258), erroring straight away would land as an unannounced red build on upgrade.

## The design constraint: provenance

The check keys on **how the value arrived**, not just on whether the command supports it:

| source | behaviour |
| --- | --- |
| Explicit CLI flag | warn — the user typed it for _this_ command |
| Shared `transloco.config.js` / `.ts` | silent — the user did nothing wrong |

One config file legitimately serves both commands, and `TranslocoGlobalConfig['keysManager']` explicitly types `emitErrorOnExtraKeys`, so a config file with that key set is correct for `find` and harmlessly inert for `extract`. Warning on it would nag on every single `extract` run of a correctly configured project and train people to ignore TKM's output.

Provenance is available for free: `command-line-args` omits options that weren't passed, so `'emitErrorOnExtraKeys' in commandLineArgs(optionDefinitions, { argv: ['--sort'] })` is `false`. Inspecting the raw parse result in `src/index.ts`, before `resolveConfig` merges in defaults and the file config, separates the two sources with no extra plumbing. There is a test locking that mechanism in, since the whole design rests on it.

## Which options are flagged

Only options **verified** unread by the other command, by tracing actual usage rather than trusting the comment blocks:

| | flagged for |
| --- | --- |
| `--output`, `--replace`, `--remove-extra-keys` | `find` |
| `--add-missing-keys`, `--emit-error-on-extra-keys` | `extract` |

### Two options that look extractor-only and are not

`--default-value` and `--sort` are deliberately **excluded**. `find` runs the same extraction pipeline as `extract` and only diverges at the end, so both reach it:

- `--default-value` supplies the value `find --add-missing-keys` writes (`addKey`). Verified — `find --add-missing-keys --default-value 'SENTINEL-{{key}}'` writes `"brand.new": "SENTINEL-brand.new"`.
- `--sort` orders that write (`writeFile` → `stringify` → `getConfig().sort`, `src/utils/object.utils.ts:6`).

`src/config.ts:52-73` groups `defaultValue` under a `Relevant only for the Extractor` comment. That comment is stale, and flagging the flag on its authority would have produced a false warning on a working setup.

`--translations-path` is also excluded even though only `find` reads it, because it doubles as the command-neutral top-level `rootTranslationsPath`; calling it `find`-only would be misleading before the config-file story is settled.

## Verified behaviour

| invocation | result |
| --- | --- |
| `extract -e` | warns, exit 0 |
| `find -R` | warns, exit 0 |
| `find -o i18n` | warns, exit 0 |
| `extract -R` | silent |
| `find -a -d '…' -s` | silent |
| `keysManager.emitErrorOnExtraKeys: true` + `extract` | silent |
| `keysManager.emitErrorOnExtraKeys: true` + `find` (extra keys present) | silent, **exit 2 as before** |

Full suite: 190 passed, 1 skipped (was 180 + 1). `tsc --noEmit` clean.

## Notes

- 5 files report Prettier drift on `master` (`src/marker.ts`, `src/keys-builder/template/*`). They are untouched here and left alone.
- Follow-up, not in this PR: the escalation to a hard error in v9, and the remaining `find` gaps from the jsverse/transloco#973 investigation.

Refs jsverse/transloco#973


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added command-specific CLI option warnings when unsupported options are provided (including a next-major-version notice).
  * Introduced `warn`-level logging support.
* **Bug Fixes**
  * Improved singular/plural phrasing for unsupported-option messaging.
  * Prevented warnings for options that are shared by commands or not actually passed on the command line.
* **Tests**
  * Expanded coverage for unsupported-option warnings, message formatting, and CLI option classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->