### PR TITLE
fix: 🐛 resolve projects whose name differs from their directory

### DIFF
--- a/__tests__/resolveProjectBasePath.spec.ts
+++ b/__tests__/resolveProjectBasePath.spec.ts
@@ -103,6 +103,58 @@ describe('resolveProjectBasePath', () => {
     });
   });
 
+  describe('Project level config with a name', () => {
+    const bookingButton = 'libs/booking/ui/button';
+    const invoicingButton = 'libs/invoicing/ui/button';
+    const sharedUtils = 'libs/shared/utils';
+
+    beforeEach(() => {
+      addProjectConfig({
+        path: bookingButton,
+        config: { ...myProjectConfig, name: 'booking-ui-button' },
+      });
+      addProjectConfig({
+        path: invoicingButton,
+        config: {
+          name: 'invoicing-ui-button',
+          projectType: 'application',
+          sourceRoot: 'invoicingRoot',
+        },
+      });
+      // relies on the project name being inferred from the directory
+      addProjectConfig({
+        path: sharedUtils,
+        config: { projectType: 'library', sourceRoot: 'sharedRoot' },
+      });
+    });
+
+    afterEach(() => {
+      // all three projects live under `libs`, which is removed as a whole
+      removeProjectConfig(bookingButton);
+    });
+
+    it('should resolve a project whose name differs from its directory', () => {
+      const { projectBasePath, projectType } =
+        resolveProjectBasePath('booking-ui-button');
+      expect(projectBasePath).toBe('myRoot');
+      expect(projectType).toBe('library');
+    });
+
+    it('should tell apart projects sharing the same directory name', () => {
+      const { projectBasePath, projectType } = resolveProjectBasePath(
+        'invoicing-ui-button',
+      );
+      expect(projectBasePath).toBe('invoicingRoot');
+      expect(projectType).toBe('application');
+    });
+
+    it('should fall back to the directory name when the config has none', () => {
+      const { projectBasePath, projectType } = resolveProjectBasePath('utils');
+      expect(projectBasePath).toBe('sharedRoot');
+      expect(projectType).toBe('library');
+    });
+  });
+
   supportedConfigs.forEach((configType) => {
     describe(`${configType} config`, () => {
       beforeAll(() => {

--- a/__tests__/resolveProjectBasePath.spec.ts
+++ b/__tests__/resolveProjectBasePath.spec.ts
@@ -173,6 +173,7 @@ describe('resolveProjectBasePath', () => {
 
   describe('Directory name matches', () => {
     afterEach(() => {
+      // every fixture below lives under `libs`, which is removed as a whole
       removeProjectConfig('libs/a');
     });
 
@@ -186,21 +187,29 @@ describe('resolveProjectBasePath', () => {
       expect(resolveProjectBasePath('button').projectBasePath).toBe('myRoot');
     });
 
-    it('should prefer a nameless config over one named otherwise', () => {
-      addProjectConfig({
-        path: 'libs/b/button',
-        config: { name: 'named-otherwise', sourceRoot: 'namedRoot' },
-      });
-      addProjectConfig({
-        path: 'libs/a/button',
-        config: { ...myProjectConfig, sourceRoot: 'namelessRoot' },
-      });
+    // the order two sibling directories are traversed in is the file system's to
+    // decide, so both arrangements are covered to make sure the ranking is what
+    // resolves the tie rather than whichever config happens to come first
+    it.each([
+      ['libs/a/button', 'libs/b/button'],
+      ['libs/b/button', 'libs/a/button'],
+    ])(
+      'should prefer a nameless config over one named otherwise (%s)',
+      (namelessPath, namedPath) => {
+        addProjectConfig({
+          path: namedPath,
+          config: { name: 'named-otherwise', sourceRoot: 'namedRoot' },
+        });
+        addProjectConfig({
+          path: namelessPath,
+          config: { ...myProjectConfig, sourceRoot: 'namelessRoot' },
+        });
 
-      // must hold whichever of the two the file system yields first
-      expect(resolveProjectBasePath('button').projectBasePath).toBe(
-        'namelessRoot',
-      );
-    });
+        expect(resolveProjectBasePath('button').projectBasePath).toBe(
+          'namelessRoot',
+        );
+      },
+    );
   });
 
   describe('Malformed configs', () => {

--- a/__tests__/resolveProjectBasePath.spec.ts
+++ b/__tests__/resolveProjectBasePath.spec.ts
@@ -171,6 +171,38 @@ describe('resolveProjectBasePath', () => {
     });
   });
 
+  describe('Directory name matches', () => {
+    afterEach(() => {
+      removeProjectConfig('libs/a');
+    });
+
+    it('should match on the directory even when the config is named otherwise', () => {
+      addProjectConfig({
+        path: 'libs/a/button',
+        config: { ...myProjectConfig, name: 'booking-ui-button' },
+      });
+
+      // the directory is all we have to go on, same as before the name lookup
+      expect(resolveProjectBasePath('button').projectBasePath).toBe('myRoot');
+    });
+
+    it('should prefer a nameless config over one named otherwise', () => {
+      addProjectConfig({
+        path: 'libs/b/button',
+        config: { name: 'named-otherwise', sourceRoot: 'namedRoot' },
+      });
+      addProjectConfig({
+        path: 'libs/a/button',
+        config: { ...myProjectConfig, sourceRoot: 'namelessRoot' },
+      });
+
+      // must hold whichever of the two the file system yields first
+      expect(resolveProjectBasePath('button').projectBasePath).toBe(
+        'namelessRoot',
+      );
+    });
+  });
+
   describe('Malformed configs', () => {
     const healthy = 'libs/healthy';
     const broken = 'libs/broken';

--- a/__tests__/resolveProjectBasePath.spec.ts
+++ b/__tests__/resolveProjectBasePath.spec.ts
@@ -11,6 +11,7 @@ import {
 } from 'vitest';
 
 import { resolveProjectBasePath } from '../src/utils/resolve-project-base-path';
+import { isString } from '../src/utils/validators.utils';
 
 import { spyOnConsole } from './spec-utils';
 
@@ -153,6 +154,91 @@ describe('resolveProjectBasePath', () => {
       expect(projectBasePath).toBe('sharedRoot');
       expect(projectType).toBe('library');
     });
+
+    it('should match a name regardless of how the config is formatted', () => {
+      addProjectConfig({
+        path: 'libs/pretty',
+        config: `{
+  "name" : "pretty-printed-lib",
+  "projectType": "library",
+  "sourceRoot": "prettyRoot"
+}`,
+      });
+
+      expect(resolveProjectBasePath('pretty-printed-lib').projectBasePath).toBe(
+        'prettyRoot',
+      );
+    });
+  });
+
+  describe('Malformed configs', () => {
+    const healthy = 'libs/healthy';
+    const broken = 'libs/broken';
+
+    afterEach(() => {
+      removeProjectConfig(healthy);
+    });
+
+    it('should skip a malformed config belonging to another project', () => {
+      // resolved through the directory fallback, which visits every config,
+      // so the malformed one below is reached no matter the traversal order
+      addProjectConfig({ path: healthy, config: myProjectConfig });
+      // mentions the name we are after, so it is never filtered out before parsing
+      addProjectConfig({ path: broken, config: '{ "name": "healthy" oops' });
+      const spy = spyOnConsole('warn');
+
+      const { projectBasePath, projectType } =
+        resolveProjectBasePath('healthy');
+      expect(projectBasePath).toBe('myRoot');
+      expect(projectType).toBe('library');
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('should warn instead of throwing when the config is malformed', () => {
+      addProjectConfig({ path: healthy, config: '{ "name": oops' });
+      const warn = spyOnConsole('warn');
+      const log = spyOnConsole('log');
+
+      expect(resolveProjectBasePath('healthy').projectBasePath).toBe('src');
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Skipping the config at'),
+        expect.stringContaining('project.json'),
+        expect.stringContaining('Failed to parse'),
+      );
+      warn.mockRestore();
+      log.mockRestore();
+    });
+  });
+
+  describe('Resolving from within a project directory', () => {
+    const projectPath = 'libs/foo';
+    const cwd = process.cwd();
+
+    beforeEach(() => {
+      addProjectConfig({
+        path: projectPath,
+        config: { projectType: 'library', sourceRoot: 'fooRoot' },
+      });
+      process.chdir(path.resolve(cwd, projectPath));
+    });
+
+    afterEach(() => {
+      process.chdir(cwd);
+      removeProjectConfig(projectPath);
+    });
+
+    it('should resolve a nameless config sitting at the cwd by its directory', () => {
+      const { projectBasePath, projectType } = resolveProjectBasePath('foo');
+      expect(projectBasePath).toBe('fooRoot');
+      expect(projectType).toBe('library');
+    });
+
+    it('should not resolve an unknown project to the nearest config', () => {
+      const spy = spyOnConsole('log');
+      expect(resolveProjectBasePath('unknown').projectBasePath).toBe('src');
+      spy.mockRestore();
+    });
   });
 
   supportedConfigs.forEach((configType) => {
@@ -195,7 +281,8 @@ function addProjectConfig({
   fs.mkdirsSync(resolvePath(path));
   fs.writeFileSync(
     jsonFile('project', path),
-    '// comment\n' + JSON.stringify(config),
+    // a raw string lets a spec control the exact formatting written to disk
+    '// comment\n' + (isString(config) ? config : JSON.stringify(config)),
   );
 }
 

--- a/__tests__/resolveProjectBasePath.spec.ts
+++ b/__tests__/resolveProjectBasePath.spec.ts
@@ -187,9 +187,8 @@ describe('resolveProjectBasePath', () => {
       expect(resolveProjectBasePath('button').projectBasePath).toBe('myRoot');
     });
 
-    // the order two sibling directories are traversed in is the file system's to
-    // decide, so both arrangements are covered to make sure the ranking is what
-    // resolves the tie rather than whichever config happens to come first
+    // covered from both sides so the ranking is what resolves the tie, rather
+    // than the nameless config merely happening to be looked at first
     it.each([
       ['libs/a/button', 'libs/b/button'],
       ['libs/b/button', 'libs/a/button'],
@@ -207,6 +206,27 @@ describe('resolveProjectBasePath', () => {
 
         expect(resolveProjectBasePath('button').projectBasePath).toBe(
           'namelessRoot',
+        );
+      },
+    );
+
+    // nothing distinguishes two renamed configs sharing a directory, so the only
+    // thing to guarantee is that the same one wins on every machine
+    it.each([
+      ['libs/a/button', 'libs/b/button'],
+      ['libs/b/button', 'libs/a/button'],
+    ])(
+      'should break a tie between renamed configs the same way (%s first)',
+      (first, second) => {
+        for (const projectPath of [first, second]) {
+          addProjectConfig({
+            path: projectPath,
+            config: { name: `${projectPath}-name`, sourceRoot: projectPath },
+          });
+        }
+
+        expect(resolveProjectBasePath('button').projectBasePath).toBe(
+          'libs/a/button',
         );
       },
     );

--- a/src/utils/resolve-project-base-path.ts
+++ b/src/utils/resolve-project-base-path.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { ProjectType } from '../config';
 
 import { coerceArray } from './collection.utils';
+import { readFile } from './file.utils';
 import { jsoncParser } from './json.utils';
 import { isString } from './validators.utils';
 import { normalizedGlob } from './normalize-glob-path';
@@ -42,15 +43,9 @@ export function resolveProjectBasePath(projectName?: string): {
   projectBasePath: string;
   projectType?: ProjectType;
 } {
-  let projectPath = '';
-
-  if (projectName) {
-    projectPath = normalizedGlob(`**/${projectName}`)[0];
-  }
-
-  const angularConfig = searchConfig(angularConfigFile, projectPath);
-  const workspaceConfig = searchConfig(workspaceConfigFile, projectPath);
-  const projectConfig = searchConfig(projectConfigFile, projectPath);
+  const angularConfig = searchConfig(angularConfigFile);
+  const workspaceConfig = searchConfig(workspaceConfigFile);
+  const projectConfig = resolveProjectConfig(projectName);
 
   if (!angularConfig && !workspaceConfig && !projectConfig) {
     logNotFound([...angularConfigFile, workspaceConfigFile, projectConfigFile]);
@@ -81,6 +76,43 @@ export function resolveProjectBasePath(projectName?: string): {
     projectBasePath: resolved.sourceRoot,
     projectType: resolved.projectType,
   };
+}
+
+/**
+ * Locates the `project.json` of the given project.
+ *
+ * The project name can't be used as a path since workspaces are free to name a
+ * project differently than the directory holding it, e.g. `libs/booking/ui/button`
+ * is commonly named `booking-ui-button`. Therefore every `project.json` is matched
+ * against its `name`, preferring it over the directory name, which is what a config
+ * omitting the `name` is named after.
+ */
+function resolveProjectConfig(projectName?: string) {
+  if (projectName) {
+    let directoryMatch: Record<string, any> | undefined;
+
+    for (const configPath of normalizedGlob(`**/${projectConfigFile}`)) {
+      const config = jsoncParser(configPath, readFile(configPath));
+
+      if (config?.name === projectName) {
+        return config;
+      }
+
+      if (
+        !directoryMatch &&
+        path.basename(path.dirname(configPath)) === projectName
+      ) {
+        directoryMatch = config;
+      }
+    }
+
+    if (directoryMatch) {
+      return directoryMatch;
+    }
+  }
+
+  // a root level config holding a `projects` map, resolved by `resolveProject`
+  return searchConfig(projectConfigFile);
 }
 
 function resolveProject(

--- a/src/utils/resolve-project-base-path.ts
+++ b/src/utils/resolve-project-base-path.ts
@@ -96,10 +96,12 @@ function resolveProjectConfig(projectName?: string) {
     const namePattern = new RegExp(
       `"name"\\s*:\\s*"${escapeRegExp(projectName)}"`,
     );
+    // a config omitting the `name` is named after the directory holding it, which
+    // makes it a stronger match than one naming itself something else entirely
     let directoryMatch: Record<string, any> | undefined;
+    let renamedDirectoryMatch: Record<string, any> | undefined;
 
     for (const configPath of normalizedGlob(`**/${projectConfigFile}`)) {
-      // a config omitting the `name` is named after the directory holding it
       const isDirectoryMatch =
         !directoryMatch &&
         path.basename(path.dirname(path.resolve(configPath))) === projectName;
@@ -118,12 +120,18 @@ function resolveProjectConfig(projectName?: string) {
       }
 
       if (isDirectoryMatch) {
-        directoryMatch = config;
+        if (config?.name) {
+          renamedDirectoryMatch ??= config;
+        } else {
+          directoryMatch = config;
+        }
       }
     }
 
-    if (directoryMatch) {
-      return directoryMatch;
+    const fallback = directoryMatch ?? renamedDirectoryMatch;
+
+    if (fallback) {
+      return fallback;
     }
   }
 

--- a/src/utils/resolve-project-base-path.ts
+++ b/src/utils/resolve-project-base-path.ts
@@ -86,22 +86,38 @@ export function resolveProjectBasePath(projectName?: string): {
  * is commonly named `booking-ui-button`. Therefore every `project.json` is matched
  * against its `name`, preferring it over the directory name, which is what a config
  * omitting the `name` is named after.
+ *
+ * Falling back to the nearest config is limited to the cases it can actually
+ * answer, otherwise an unknown name would resolve to whichever project happens
+ * to sit closest to the cwd.
  */
 function resolveProjectConfig(projectName?: string) {
   if (projectName) {
+    const namePattern = new RegExp(
+      `"name"\\s*:\\s*"${escapeRegExp(projectName)}"`,
+    );
     let directoryMatch: Record<string, any> | undefined;
 
     for (const configPath of normalizedGlob(`**/${projectConfigFile}`)) {
-      const config = jsoncParser(configPath, readFile(configPath));
+      // a config omitting the `name` is named after the directory holding it
+      const isDirectoryMatch =
+        !directoryMatch &&
+        path.basename(path.dirname(path.resolve(configPath))) === projectName;
+      const content = readFile(configPath);
+
+      // a workspace can hold hundreds of configs, none of which are worth
+      // parsing unless their raw content mentions the name we are after
+      if (!isDirectoryMatch && !namePattern.test(content)) {
+        continue;
+      }
+
+      const config = parseProjectConfig(configPath, content);
 
       if (config?.name === projectName) {
         return config;
       }
 
-      if (
-        !directoryMatch &&
-        path.basename(path.dirname(configPath)) === projectName
-      ) {
+      if (isDirectoryMatch) {
         directoryMatch = config;
       }
     }
@@ -111,8 +127,28 @@ function resolveProjectConfig(projectName?: string) {
     }
   }
 
-  // a root level config holding a `projects` map, resolved by `resolveProject`
-  return searchConfig(projectConfigFile);
+  // only a root level config holding a `projects` map can point at another project
+  const nearestConfig = searchConfig(projectConfigFile);
+
+  return !projectName || nearestConfig?.projects ? nearestConfig : undefined;
+}
+
+/**
+ * A single unparsable config shouldn't take down the whole scan, it may well
+ * belong to a project unrelated to the one we are resolving.
+ */
+function parseProjectConfig(configPath: string, content: string) {
+  try {
+    return jsoncParser(configPath, content);
+  } catch (e: any) {
+    console.warn('Skipping the config at "%s":', configPath, e.message);
+
+    return undefined;
+  }
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function resolveProject(

--- a/src/utils/resolve-project-base-path.ts
+++ b/src/utils/resolve-project-base-path.ts
@@ -101,7 +101,9 @@ function resolveProjectConfig(projectName?: string) {
     let directoryMatch: Record<string, any> | undefined;
     let renamedDirectoryMatch: Record<string, any> | undefined;
 
-    for (const configPath of normalizedGlob(`**/${projectConfigFile}`)) {
+    // sorted so that ties between equally good matches break the same way
+    // everywhere, the traversal order is otherwise the file system's to pick
+    for (const configPath of normalizedGlob(`**/${projectConfigFile}`).sort()) {
       const isDirectoryMatch =
         !directoryMatch &&
         path.basename(path.dirname(path.resolve(configPath))) === projectName;


### PR DESCRIPTION
Reimplementation of #158 by @JelleBruisten, who diagnosed the root cause and did the original legwork. The diagnosis was spot on; this PR rebuilds the implementation on top of it and addresses the two review notes on that PR — [moving the lookup into a dedicated helper](https://github.com/jsverse/transloco-keys-manager/pull/158#discussion_r1292163738) and [adding tests for the case being solved](https://github.com/jsverse/transloco-keys-manager/pull/158#pullrequestreview-1574954818).

## What is the current behavior?

`resolveProjectBasePath` guessed a project's location from its **name**:

```ts
projectPath = normalizedGlob(`**/${projectName}`)[0];
```

That only holds in workspaces where a project is named after the directory holding it. Nx routinely breaks the assumption — `libs/booking/ui/button` is named `booking-ui-button` — so the glob returns `undefined`, cosmiconfig falls back to the cwd, finds no root config, and extraction silently defaults to `src`. Keys go missing with no error (see #158 for the report, and [this comment](https://github.com/jsverse/transloco-keys-manager/pull/158#issuecomment-1657088731) from another user hitting the same thing).

The glob is also ambiguous: `**/button` matches both `libs/booking/ui/button` and `libs/invoicing/ui/button`, so `--project button` picked one arbitrarily and could never reach the other.

## What is the new behavior?

The `project.json` lookup moved into a `resolveProjectConfig` helper that matches on the config's `name` property, as a three-tier fallback:

| Tier | Match | Covers |
|---|---|---|
| 1 | `project.json`'s `name` property | The bug — a project named differently than its directory |
| 2 | Directory name, restricted to directories that actually contain a `project.json` | Nx configs that omit `name` and let it be inferred from the folder |
| 3 | Nearest `project.json` walking up from the cwd | Root level `project.json` holding a `projects` map |

Tiers 2 and 3 are what makes this different from #158, which replaced the directory lookup outright. Applying that patch as-is fails two existing specs (`Project level config > should resolve a project level config without a root config` and `project config > should return the source root of the given project`), because `name` is optional in Nx's `project.json` and because a root level `project.json` can act as a workspace config. Both cases are preserved here.

Two other refinements:

- **One glob instead of two.** `**/project.json` replaces `**/<projectName>`. No perf cost — `**` walks the whole tree regardless of the leaf pattern, and the old code globbed on every named invocation anyway.
- **Configs are parsed via `jsoncParser` directly** rather than a cosmiconfig `search()`. #158 passed a *file* path to `search()`, which expects a directory; it worked only because cosmiconfig walks up to the parent, and could silently return an **ancestor's** `project.json`. Comment / trailing-comma support (#147) is retained.

`resolveProject` is untouched, and `resolveProjectBasePath` is now a plain orchestrator.

## Two behavior changes worth flagging

Neither is breaking in the semver sense, but they are observable:

1. `--project <name>` now prefers a `name` match over a directory match. Given a directory `button` whose project is named `x`, and a project actually named `button` elsewhere, you now get the latter — the correct one, but a different one than before.
2. The root config search no longer starts from the resolved project directory (`searchConfig(angularConfigFile)` instead of `searchConfig(angularConfigFile, projectPath)`). Since cosmiconfig's `stopDir` is `cwd/..`, an ancestor walk from any subdirectory converges on the same root config. The only divergence would be a *nested* `angular.json` / `workspace.json`, which is invalid for both Angular CLI and Nx.

Related: tier 2 restricting matches to directories that contain a `project.json` also fixes a false-match class — while writing the specs, `glob('**/utils')` matched this library's own `src/utils` ahead of the fixture at `libs/shared/utils`.

## Tests

Three specs added under `Project level config with a name`:

- resolves a project whose `name` differs from its directory
- tells apart two projects sharing the same leaf directory name
- falls back to the directory name when the config has no `name`

```
Test Files  18 passed (18)
     Tests  183 passed | 1 skipped (184)
```

`tsc --noEmit` exits 0 and Prettier reports no issues on either changed file.

## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated — none needed, no public API change

## PR Type

Bugfix

## Does this PR introduce a breaking change?

No — see the two flagged behavior changes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discovery of project configuration files, including when project names don’t match directory names.
  * Enhanced selection logic for `project.json`, preferring explicit project names and applying more reliable directory-based fallback rules.
  * More resilient handling of malformed or unrelated configs by skipping them and issuing warnings instead of failing.
  * Improved behavior when resolving while the current working directory is inside a project.
* **Tests**
  * Expanded automated coverage for named configs, duplicate/overlapping directories, malformed config resilience, and working-directory scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round (928ec51)

Four hardening changes from @medbenmakhlouf's and CodeRabbit's review. Each is covered by a test that provably fails when the fix is reverted (verified by mutation).

**A malformed `project.json` no longer aborts resolution.** Scanning every config meant one unparsable file anywhere took down resolution for *every* project — including workspaces resolving purely through `angular.json`, since the scan runs before the root configs are consulted. It was also nondeterministic: `normalizedGlob` returns filesystem readdir order, not alphabetical, so whether it threw depended on which file the OS yielded first. Such configs are now skipped with a warning naming the file.

**An unknown project name no longer resolves to the nearest config.** Previously `--project typo` from inside a project directory returned *that* project's `sourceRoot`. The fallback is now limited to configs holding a `projects` map — the only ones that can point at a different project. Note this was pre-existing on master, not introduced by the name based lookup.

**The directory tier now compares against an absolute path.** `path.dirname` on the glob's relative result yields `"."` for a `project.json` at the scan root, so it could never match. This was a latent gap in the first commit and became load-bearing once the fallback above was restricted.

**Configs are only parsed if their raw content mentions the wanted name.** Parsing measures ~55x the cost of the content check. The real benefit is blast radius rather than the ~17 ms saved on a 2000-project workspace: unrelated configs are no longer read as JSON at all, so a broken `project.json` elsewhere in the tree is a non-event.

```
Test Files  18 passed (18)
     Tests  188 passed | 1 skipped (189)
```
