### PR TITLE
docs: mark repository as archived/read-only, redirect to jsverse/transloco 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]  
-> **This repository is now read-only / archived.** The codebase has moved to the [jsverse/transloco](https://github.com/jsverse/transloco) monorepo. Don't panic — development on this package continues, just under its new home! Please open new issues, discussions, and pull requests there instead of here.
+> **This repository is now read-only / archived.** The codebase has moved to the [jsverse/transloco](https://github.com/jsverse/transloco) monorepo. Don't panic — development on this package continues, just with its friends! Please open new issues, discussions, and pull requests there instead of here.
 >
 > The Transloco packages are now published under the **@jsverse** scope, update your dependencies to get the latest features 🚀
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 > [!IMPORTANT]  
+> **This repository is now read-only / archived.** The codebase has moved to the [jsverse/transloco](https://github.com/jsverse/transloco) monorepo. Don't panic — development on this package continues, just under its new home! Please open new issues, discussions, and pull requests there instead of here.
+>
 > The Transloco packages are now published under the **@jsverse** scope, update your dependencies to get the latest features 🚀
 
 <p align="center">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The README did not clearly communicate that this repository is being archived and moved into the jsverse/transloco monorepo, which could lead visitors to keep filing issues/PRs here.

Issue Number: N/A

## What is the new behavior?

Added a prominent notice at the top of the README stating the repository is now read-only, the codebase has moved to https://github.com/jsverse/transloco, development continues there, and new issues/PRs should be submitted in the new repo.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Documentation-only change, no code or API impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a prominent notice that the repository is archived and read-only.
  - Directed users to the new project location for development, issues, discussions, and pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->